### PR TITLE
Bug 1233748 - Update contributing docs with autolander information.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,10 @@ create this easily).
 should only take a few minutes.
   * It is useful to make sure the tests pass (are green) before requesting review,
 otherwise your patch will be rejected.
-* The pull request should be attached to the bug, and reviewer(s) requested (there
-is a suggested list of reviewers to pick from if you don't know who to ask).
-  * Use [github tweaks for bugzilla](https://addons.mozilla.org/en-US/firefox/addon/github-tweaks-for-bugzilla/) firefox add-on to make this easier.
+* [Autolander](#autolander-bot) will automatically attach the pull request to the bug assuming the
+pull request title is formatted correctly.
+* Reviewers should be suggested, there is a suggested list of reviewers to pick from
+if you don't know who to ask.
 * If a pull request changes the UI then you should also attach screenshots or short
 videos to the bug and request ui-review on those from :sevaan and :pau
 
@@ -76,3 +77,15 @@ it doesn't need to. r=Standard8`
   * master should then be merged with the branch via fast-forward only:
     * `git merge --ff master`
   * If it was successful, push the result
+
+Autolander (bot)
+----------------
+
+Autolander is a bot which integrates github and bugzilla workflows.
+
+Features available:
+  - Automatic pull request to bugzilla attachment linking.
+  - Automatic landing with a R+ from a suggested reviewer and the autoland keyword.
+  - Comments in the bug with the landed commit, and marks the bug as fixed.
+  - Validates pull request title and commit message formats.
+  - [Autolander on Github](https://github.com/mozilla/autolander)


### PR DESCRIPTION
This does not include adding the `autoland` keyword, as that conflicts with the existing workflow.
