### PR TITLE
Remove error message about favicon when the error is just not-found.

### DIFF
--- a/add-on/chrome/modules/MozLoopAPI.jsm
+++ b/add-on/chrome/modules/MozLoopAPI.jsm
@@ -594,7 +594,7 @@ const kMessageHandlers = {
       win.messageManager.removeMessageListener("PageMetadata:PageDataResult", onPageDataResult);
       let pageData = msg.json;
       win.LoopUI.getFavicon(function(err, favicon) {
-        if (err) {
+        if (err && err !== "favicon not found for uri") {
           MozLoopService.log.error("Error occurred whilst fetching favicon", err);
           // We don't return here intentionally to make sure the callback is
           // invoked at all times. We just report the error here.


### PR DESCRIPTION
This fixes PR #44, where I accidentally included a commit.  I'm recreating the pull request due to not using a branch originally.

An example site that emits this warning continuously is https://bugzilla.mozilla.org
