### PR TITLE
Ignore the pep8 error for module imports not being at the top of the …

### DIFF
--- a/bin/require.pip
+++ b/bin/require.pip
@@ -1,2 +1,7 @@
-flake8
+# Note: For flake 8 we include its dependencies so that we can fix their versions
+# to avoid updating when we don't expect it.
+flake8==2.5.1
+pep8==1.6.0
+mccabe==0.3.1
+pyflakes==1.0.0
 mozbuild==0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 exclude = built,dist,node_modules,test/functional
 max-line-length = 120
+# E402 module level import not at top of file (test files need to set up paths)
+ignore=E402


### PR DESCRIPTION
…file and fix versions of flake8 dependencies to stop them being updated underneath us.
