### PR TITLE
Bug 1239780 - Port Bug 1101817 - Part 5: Remove WeakMap.prototype.clear from Loop addon. Also account for different Firefox versions.

### DIFF
--- a/add-on/chrome/modules/MozLoopService.jsm
+++ b/add-on/chrome/modules/MozLoopService.jsm
@@ -950,7 +950,13 @@ var MozLoopServiceInternal = {
         let window = chatbox.contentWindow;
 
         function socialFrameChanged(eventName) {
-          UITour.availableTargetsCache.clear();
+          // `clearAvailableTargetsCache` is new in Firefox 46. The else branch
+          // supports Firefox 45.
+          if ("clearAvailableTargetsCache" in UITour) {
+            UITour.clearAvailableTargetsCache();
+          } else {
+            UITour.availableTargetsCache.clear();
+          }
           UITour.notify(eventName);
 
           if (eventName == "Loop:ChatWindowDetached" || eventName == "Loop:ChatWindowAttached") {


### PR DESCRIPTION
This fixes the add-on running against latest nightly - Bug 1101817 changed the API, so we need to detect that and select the call appropriately.
