### PR TITLE
Bug 1238509 - Drop some obsolete preferences. r=Standard8

### DIFF
--- a/add-on/panels/js/conversation.jsx
+++ b/add-on/panels/js/conversation.jsx
@@ -106,7 +106,6 @@ loop.conversation = (function(mozL10n) {
       ["GetAllStrings"],
       ["GetLocale"],
       ["GetLoopPref", "ot.guid"],
-      ["GetLoopPref", "textChat.enabled"],
       ["GetLoopPref", "feedback.periodSec"],
       ["GetLoopPref", "feedback.dateLastSeenSec"],
       ["GetLoopPref", "facebook.enabled"]
@@ -152,14 +151,11 @@ loop.conversation = (function(mozL10n) {
         }
       });
 
-      // We want data channels only if the text chat preference is enabled.
-      var useDataChannels = results[++requestIdx];
-
       var dispatcher = new loop.Dispatcher();
       var sdkDriver = new loop.OTSdkDriver({
         constants: constants,
         isDesktop: true,
-        useDataChannels: useDataChannels,
+        useDataChannels: true,
         dispatcher: dispatcher,
         sdk: OT
       });

--- a/add-on/preferences/prefs.js
+++ b/add-on/preferences/prefs.js
@@ -1,12 +1,10 @@
 pref("loop.enabled", true);
-pref("loop.textChat.enabled", true);
 pref("loop.server", "https://loop.services.mozilla.com/v0");
 pref("loop.linkClicker.url", "https://hello.firefox.com/");
 pref("loop.gettingStarted.latestFTUVersion", 1);
 pref("loop.facebook.shareUrl", "https://www.facebook.com/sharer/sharer.php?u=%ROOM_URL%");
 pref("loop.gettingStarted.url", "https://www.mozilla.org/%LOCALE%/firefox/%VERSION%/hello/start/");
 pref("loop.gettingStarted.resumeOnFirstJoin", false);
-pref("loop.learnMoreUrl", "https://www.firefox.com/hello/");
 pref("loop.legal.ToS_url", "https://www.mozilla.org/about/legal/terms/firefox-hello/");
 pref("loop.legal.privacy_url", "https://www.mozilla.org/privacy/firefox-hello/");
 pref("loop.do_not_disturb", false);


### PR DESCRIPTION
Removed all unused references of loop.textChat.enabled and loop.learnMoreUrl.
