### PR TITLE
Bug 1240554 ui showcase enable facebook fix

### DIFF
--- a/shared/js/linkifiedTextView.jsx
+++ b/shared/js/linkifiedTextView.jsx
@@ -86,13 +86,17 @@ loop.shared.views.LinkifiedTextView = (function() {
 
         // Push the first link itself, and advance the string pointer again.
         // Bug 1196143 - formatURL sanitizes(decodes) the URL from IDN homographic attacks.
-        sanitizeURL = loop.shared.utils.formatURL(result[0]).location;
-        elements.push(
-          <a { ...this._generateLinkAttributes(sanitizeURL) }
-            key={reactElementsCounter++}>
-            {sanitizeURL}
-          </a>
-        );
+        sanitizeURL = loop.shared.utils.formatURL(result[0]);
+        if (sanitizeURL && sanitizeURL.location) {
+          elements.push(
+            <a { ...this._generateLinkAttributes(sanitizeURL.location) }
+              key={reactElementsCounter++}>
+              {sanitizeURL.location}
+            </a>
+          );
+        } else {
+          elements.push(result[0]);
+        }
         s = s.substr(result[0].length);
 
         // Check for another link, and perhaps continue...

--- a/shared/js/utils.js
+++ b/shared/js/utils.js
@@ -386,18 +386,18 @@ var inChrome = typeof Components != "undefined" && "utils" in Components;
     var urlObject;
     try {
       urlObject = new URL(url);
+      // Finally, ensure we look good.
+      return {
+        hostname: urlObject.hostname,
+        location: decodeURI(urlObject.href)
+      };
     } catch (ex) {
       if (suppressConsoleError ? !suppressConsoleError : true) {
-        console.error("Error occurred whilst parsing URL:", ex);
+        console.log("Error occurred whilst parsing URL: ", ex);
+        console.trace();
       }
       return null;
     }
-
-    // Finally, ensure we look good.
-    return {
-      hostname: urlObject.hostname,
-      location: decodeURI(urlObject.href)
-    };
   }
 
   /**

--- a/shared/test/linkifiedTextView_test.js
+++ b/shared/test/linkifiedTextView_test.js
@@ -310,6 +310,11 @@ describe("loop.shared.views.LinkifiedTextView", function() {
           rawText: "//C/Programs",
           markup: "<p>//C/Programs</p>"
         },
+        {
+          desc: "should not linkify malformed URI sequences",
+          rawText: "http://www.example.com/DNA/pizza/menu/lots-of-different-kinds-of-pizza/%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%",
+          markup: "<p>http://www.example.com/DNA/pizza/menu/lots-of-different-kinds-of-pizza/%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%</p>"
+        },
         // do a few tests to convince ourselves that, when our code is handled
         // HTML in the input box, the integration of our code with React should
         // cause that to rendered to appear as HTML source code, rather than

--- a/shared/test/utils_test.js
+++ b/shared/test/utils_test.js
@@ -296,7 +296,7 @@ describe("loop.shared.utils", function() {
   describe("#formatURL", function() {
     beforeEach(function() {
       // Stub to prevent console messages.
-      sandbox.stub(window.console, "error");
+      sandbox.stub(window.console, "log");
     });
 
     it("should decode encoded URIs", function() {
@@ -318,14 +318,17 @@ describe("loop.shared.utils", function() {
         });
     });
 
-    it("should return null if it the url is not valid", function() {
-      expect(sharedUtils.formatURL("hinvalid//url")).eql(null);
+    it("should return null if suppressConsoleError is true and the url is not valid", function() {
+      expect(sharedUtils.formatURL("hinvalid//url", true)).eql(null);
     });
 
-    it("should log an error message to the console", function() {
-      sharedUtils.formatURL("hinvalid//url");
+    it("should return null if suppressConsoleError is true and is a malformed URI sequence", function() {
+      expect(sharedUtils.formatURL("http://www.example.com/DNA/pizza/menu/lots-of-different-kinds-of-pizza/%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%", true)).eql(null);
+    });
 
-      sinon.assert.calledOnce(console.error);
+    it("should log a malformed URI sequence error to the console", function() {
+      sharedUtils.formatURL("http://www.example.com/DNA/pizza/menu/lots-of-different-kinds-of-pizza/%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%");
+      sinon.assert.calledOnce(console.log);
     });
   });
 

--- a/ui/ui-showcase.jsx
+++ b/ui/ui-showcase.jsx
@@ -855,6 +855,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   roomState={ROOM_STATES.INIT}
@@ -873,6 +874,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"
@@ -890,6 +892,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"
@@ -907,6 +910,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"
@@ -924,6 +928,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"
@@ -941,6 +946,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"
                   roomStore={desktopLocalFaceMuteRoomStore} />
@@ -956,6 +962,7 @@
                 <DesktopRoomConversationView
                   chatWindowDetached={false}
                   dispatcher={dispatcher}
+                  facebookEnabled={true}
                   localPosterUrl="sample-img/video-screen-local.png"
                   onCallTerminated={function() {}}
                   remotePosterUrl="sample-img/video-screen-remote.png"


### PR DESCRIPTION
@dmose @Standard8: Added tests for parseStringToElements and formatURL.  Only issue is that shared tests fails for the Unexpected Logged Warnings and Errors Check because parseStringToElements test that I added emits an error.  How do we send true for the suppressConsoleError in the LinkifiedTextView_test to not emit the error -OR- do we remove the test -OR- do we set parseStringToElements call to formatURL to suppressConsoleError(no errors ever emitted)?
