### PR TITLE
Hack our way around functional test breakage caused by Ubuntu auto-in…

### DIFF
--- a/test/functional/config.py
+++ b/test/functional/config.py
@@ -19,5 +19,14 @@ FIREFOX_PREFERENCES = {
     # this dialog is fragile, and likely to introduce intermittent failures
     "media.navigator.permission.disabled": True,
     # Use fake streams only
-    "media.navigator.streams.fake": True
+    "media.navigator.streams.fake": True,
+
+    # attempts to work around Ubuntu wanting to install add-ons
+    "extensions.enabledScopes": 5,
+    "extensions.autoDisableScopes": 0,
+    "extensions.update.enabled": False,
+    "extensions.installDistroAddons": False,
+    "extensions.blocklist.enabled": False,
+    "extensions.update.notifyUser": False,
+    "xpinstall.signatures.required": False,
 }


### PR DESCRIPTION
…stalling add-ons.

Going to let @Standard8 have a look at this.  I'm pretty surprised that turning off the blocklist and the xpinstall signature stuff was necessary for the Ubuntu add-on.  Or was that to fix the fact that we're now a system add-on?  Question is really for @nils-ohlmeier...
