### PR TITLE
Fix the tiles support url used for local standalone server instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,5 +451,5 @@ config:
 	@echo "loop.config.learnMoreUrl = '`echo $(LOOP_PRODUCT_HOMEPAGE_URL)`';" >> content/config.js
 	@echo "loop.config.generalSupportUrl = 'https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode';" >> content/config.js
 	@echo "loop.config.tilesIframeUrl = 'https://tiles.cdn.mozilla.net/iframe.html';" >> content/config.js
-	@echo "loop.config.tilesSupportUrl = 'https://support.mozilla.org/tiles-firefox-hello';" >> content/config.js
+	@echo "loop.config.tilesSupportUrl = 'https://support.mozilla.org/kb/tiles-firefox-hello';" >> content/config.js
 	@echo "loop.config.unsupportedPlatformUrl = 'https://support.mozilla.org/en-US/kb/which-browsers-will-work-firefox-hello-video-chat';" >> content/config.js

--- a/bin/server.js
+++ b/bin/server.js
@@ -49,7 +49,7 @@ function getConfigFile(req, res) {
     "loop.config.learnMoreUrl = 'https://www.mozilla.org/hello/';",
     "loop.config.legalWebsiteUrl = 'https://www.mozilla.org/about/legal/terms/firefox-hello/';",
     "loop.config.tilesIframeUrl = 'https://tiles.cdn.mozilla.net/iframe.html';",
-    "loop.config.tilesSupportUrl = 'https://support.mozilla.org/tiles-firefox-hello';",
+    "loop.config.tilesSupportUrl = 'https://support.mozilla.org/kb/tiles-firefox-hello';",
     "loop.config.generalSupportUrl = 'https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode';",
     "loop.config.unsupportedPlatformUrl = 'https://support.mozilla.org/en-US/kb/which-browsers-will-work-firefox-hello-video-chat'"
   ].join("\n"));


### PR DESCRIPTION
This fixes the URL used for our local instances of standalone to be the current one for the support about the tiles. Hence, matching to production and saving any confusion.
