### PR TITLE
Bug 1239241 - Facebook SEND button for sharing conversation

### DIFF
--- a/add-on/preferences/prefs.js
+++ b/add-on/preferences/prefs.js
@@ -3,7 +3,6 @@ pref("loop.remote.autostart", false);
 pref("loop.server", "https://loop.services.mozilla.com/v0");
 pref("loop.linkClicker.url", "https://hello.firefox.com/");
 pref("loop.gettingStarted.latestFTUVersion", 1);
-pref("loop.facebook.shareUrl", "https://www.facebook.com/sharer/sharer.php?u=%ROOM_URL%");
 pref("loop.gettingStarted.url", "https://www.mozilla.org/%LOCALE%/firefox/%VERSION%/hello/start/");
 pref("loop.gettingStarted.resumeOnFirstJoin", false);
 pref("loop.legal.ToS_url", "https://www.mozilla.org/about/legal/terms/firefox-hello/");
@@ -34,3 +33,6 @@ pref("loop.facebook.enabled", true);
 #else
 pref("loop.facebook.enabled", false);
 #endif
+pref("loop.facebook.appId", "1519239075036718");
+pref("loop.facebook.shareUrl", "https://www.facebook.com/dialog/send?app_id=%APP_ID%&link=%ROOM_URL%&redirect_uri=%REDIRECT_URI%");
+pref("loop.facebook.fallbackUrl", "https://hello.firefox.com/");

--- a/shared/js/actions.js
+++ b/shared/js/actions.js
@@ -396,11 +396,13 @@ loop.shared.actions = (function() {
      * XXX: should move to some roomActions module - refs bug 1079284
      * @from: where the invitation is shared from.
      *        Possible values ['panel', 'conversation']
-     * @roomUrl: the URL that is shared
+     * @roomUrl: the URL that is shared.
+     * @roomOrigin: the URL browsed when the sharing is started - Optional.
      */
     FacebookShareRoomUrl: Action.define("facebookShareRoomUrl", {
       from: String,
       roomUrl: String
+      // roomOrigin: String
     }),
 
     /**

--- a/standalone/content/index.html
+++ b/standalone/content/index.html
@@ -9,6 +9,8 @@
     <meta name="default_locale" content="en-US" />
     <meta name="referrer" content="origin" />
 
+    <!-- FB Open Graph -->
+    <meta property="fb:app_id" content="1519239075036718" />
     <meta property="og:image" content="https://hello.firefox.com/img/invitation.png" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
while we manage to close the tab after facebook success redirection, or use a popup instead of a tab,
we will go for a redirection to the original URL that the link-generator was visiting, or a fallback to `hello.firefox.com` if no link available (e.g. about:<something> pages)
