### PR TITLE
Bug 1245150 - Change state at which to trigger StartBrowserShare action

### DIFF
--- a/add-on/chrome/modules/MozLoopAPI.jsm
+++ b/add-on/chrome/modules/MozLoopAPI.jsm
@@ -200,6 +200,16 @@ const kMessageHandlers = {
   },
 
   /**
+   * Triggered at ROOM_STATES.SESSION_CONNECTED meant to notify the connection
+   * status.
+   */
+  RoomSessionConnected: function(message, reply) {
+    let win = Services.wm.getMostRecentWindow("navigator:browser");
+    win.LoopUI.roomSessionConnected();
+    reply();
+  },
+
+  /**
    * Creates a layout for the remote cursor on the browser chrome,
    * and positions it on the received coordinates.
    *

--- a/add-on/panels/js/roomViews.jsx
+++ b/add-on/panels/js/roomViews.jsx
@@ -190,12 +190,9 @@ loop.roomViews = (function(mozL10n) {
         }));
       }
 
-      // Now that we're ready to share, automatically start sharing a tab only
-      // if we're not already connected to the room via the sdk, e.g. not in the
-      // case a remote participant just left.
-      if (nextState.roomState === ROOM_STATES.SESSION_CONNECTED &&
-          !(this.state.roomState === ROOM_STATES.SESSION_CONNECTED ||
-            this.state.roomState === ROOM_STATES.HAS_PARTICIPANTS)) {
+      // Automatically start sharing a tab now we're ready to share.
+      if (this.state.roomState === ROOM_STATES.MEDIA_WAIT &&
+          nextState.roomState === ROOM_STATES.JOINING) {
         this.props.dispatcher.dispatch(new sharedActions.StartBrowserShare());
       }
     },

--- a/add-on/panels/js/roomViews.jsx
+++ b/add-on/panels/js/roomViews.jsx
@@ -195,6 +195,12 @@ loop.roomViews = (function(mozL10n) {
           nextState.roomState === ROOM_STATES.JOINING) {
         this.props.dispatcher.dispatch(new sharedActions.StartBrowserShare());
       }
+
+      // Notify of connection status update.
+      if (this.state.roomState !== ROOM_STATES.SESSION_CONNECTED &&
+          nextState.roomState === ROOM_STATES.SESSION_CONNECTED) {
+        this.props.dispatcher.dispatch(new sharedActions.RoomSessionConnected());
+      }
     },
 
     /**

--- a/add-on/panels/test/roomViews_test.js
+++ b/add-on/panels/test/roomViews_test.js
@@ -375,11 +375,11 @@ describe("loop.roomViews", function() {
             }));
         });
 
-      it("should dispatch a `StartBrowserShare` action when the SESSION_CONNECTED state is entered", function() {
-        activeRoomStore.setStoreState({ roomState: ROOM_STATES.READY });
+      it("should dispatch a `StartBrowserShare` action when state goes from MEDIA_WAIT to JOINING a room", function() {
+        activeRoomStore.setStoreState({ roomState: ROOM_STATES.MEDIA_WAIT });
         mountTestComponent();
 
-        activeRoomStore.setStoreState({ roomState: ROOM_STATES.SESSION_CONNECTED });
+        activeRoomStore.setStoreState({ roomState: ROOM_STATES.JOINING });
 
         sinon.assert.calledOnce(dispatcher.dispatch);
         sinon.assert.calledWithExactly(dispatcher.dispatch,

--- a/shared/js/actions.js
+++ b/shared/js/actions.js
@@ -237,6 +237,12 @@ loop.shared.actions = (function() {
     }),
 
     /**
+     * Used to notify of room connection status.
+     */
+    RoomSessionConnected: Action.define("roomSessionConnected", {
+    }),
+
+    /**
      * Used to end a screen share.
      */
     EndScreenShare: Action.define("endScreenShare", {

--- a/shared/js/activeRoomStore.js
+++ b/shared/js/activeRoomStore.js
@@ -269,6 +269,7 @@ loop.store.ActiveRoomStore = (function(mozL10n) {
         "remoteVideoStatus",
         "videoDimensionsChanged",
         "startBrowserShare",
+        "roomSessionConnected",
         "endScreenShare",
         "toggleBrowserSharing",
         "updateSocialShareInfo",
@@ -991,6 +992,10 @@ loop.store.ActiveRoomStore = (function(mozL10n) {
       loop.request("AddBrowserSharingListener", this.getStoreState().windowId)
         .then(this._browserSharingListener);
       loop.subscribe("BrowserSwitch", this._browserSharingListener);
+    },
+
+    roomSessionConnected: function() {
+      loop.request("RoomSessionConnected");
     },
 
     /**


### PR DESCRIPTION
Previously StartBrowserShare was dispatched when state changed to room
joined (this is seconds later after the conversation window had already opened).
The issue was that the conversation window and the share tab infobar
appeared at different moments of time.

---

Here is a gif of the infobar action in progress

[gif of solution](http://i.imgur.com/VoieEox.gifv)

I've added the event dispatch at the soonest moment it made sense, after media access has been granted just before joining the room. It is better synchronized with the conversation window that popups up. Are there any concerns about those events? Is there a scenario when the application might not go through those 2 states?
