### PR TITLE
Bug 1250847 - prefix DOMWindowClose with the Social: prefix to assure …

### DIFF
--- a/add-on/chrome/modules/MozLoopService.jsm
+++ b/add-on/chrome/modules/MozLoopService.jsm
@@ -1005,7 +1005,7 @@ var MozLoopServiceInternal = {
 
           // Handle window.close correctly on the chatbox.
           mm.sendAsyncMessage("Social:HookWindowCloseForPanelClose");
-          messageName = "DOMWindowClose";
+          messageName = "Social:DOMWindowClose";
           mm.addMessageListener(messageName, listeners[messageName] = () => {
             // Remove message listeners.
             for (let name of Object.getOwnPropertyNames(listeners)) {


### PR DESCRIPTION
…they won’t arrive at the global messageManager instance that TabBrowser is listening to. It mixes things up in twisted, unexpected ways if we don’t. r=Standard8
