### PR TITLE
No bug. Attempt to fix intermittent functional test failures (30 second timeout exceeded waiting for remote-video)

### DIFF
--- a/add-on/panels/js/panel.jsx
+++ b/add-on/panels/js/panel.jsx
@@ -1062,12 +1062,12 @@ loop.panel = (function(_, mozL10n) {
 
     handleClosePanel: function() {
       this.props.onSharePanelDisplayChange();
+      this.openRoom();
+      this.closeWindow();
+
       this.setState({
         showPanel: false
       });
-
-      this.openRoom();
-      this.closeWindow();
     },
 
     openRoom: function() {


### PR DESCRIPTION
We've been seeing lots of intermittent failures for a while. I think the latest ones are due to the new share panel within the main loop panel.

I've seen it on the functional test server, that the panel sometimes can stay open, covering up the next button to click on the standalone.

My current best guess is this patch - I think what might be happening is that the setState for hiding the share panel is occurring before the openRoom/closeWindow calls - because of that, there's a possibility that the share panel component elements have disappeared before the openRoom/closeWindow get called (or just closeWindow as I've seen).

Hence, I think we should try swapping the order of these, to ensure the required functions are called before the setState.

I could be completely wrong, but I think we should try this as a first attempt.
