### PR TITLE
No bug. Update python packages to the latest version and improve handling of our pip requirements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ RSYNC := rsync --archive --exclude='*.jsx'
 
 .PHONY: install
 install: node_modules
-	pip install -r require.pip
 
 node_modules: package.json
 	@mkdir -p node_modules

--- a/bin/require.pip
+++ b/bin/require.pip
@@ -1,12 +1,33 @@
-# Note: For flake 8 we include its dependencies so that we can fix their versions
-# to avoid updating when we don't expect it.
-flake8==2.5.1
-pep8==1.6.0
-mccabe==0.3.1
-pyflakes==1.0.0
-mozbuild==0.2
+# If you add new dependencies, please regenerate with `pip freeze` to ensure
+# all sub-dependencies are included.
+blessings==1.6
+browsermob-proxy==0.7.1
+flake8==2.5.4
 gitchangelog==2.3.0
+gitdb==0.6.4
+GitPython==1.0.2
+jsmin==2.2.1
+manifestparser==1.1
+marionette-client==2.3.0
+marionette-driver==1.4.0
+marionette-transport==1.2.0
+mccabe==0.4.0
+mozbuild==0.2
+mozcrash==0.17
+mozdevice==0.48
+mozfile==1.2
+mozinfo==0.9
+mozlog==3.1
+moznetwork==0.27
+mozprocess==0.22
+mozprofile==0.28
+mozrunner==6.11
+moztest==0.7
+mozversion==1.4
+pep8==1.7.0
+pyflakes==1.1.0
+pyperclip==1.5.27
 pystache==0.5.4
-gitpython==1.0.1
-marionette_client==2.2.0
-pyperclip==1.5.26
+requests==2.9.1
+smmap==0.9.0
+wptserve==1.4.0

--- a/docs/Developing.md
+++ b/docs/Developing.md
@@ -10,6 +10,9 @@ will provide some tools for the command line.
 Assuming you have the basic utilities, then you also need:
 
 * [node.js](https://nodejs.org/). Version 0.10 is currently required.
+* [Python](https://www.python.org/). Version 2.7 is currently used.
+** [pip](https://pip.pypa.io/en/stable/)
+** [virtualenv](https://pypi.python.org/pypi/virtualenv), installed globally via pip.
 * For testing and developing the add-on:
   * Any Firefox build later than 45.0a1, although
     [nightly](https://nightly.mozilla.org/) is typically used by Loop's developers.

--- a/require.pip
+++ b/require.pip
@@ -1,2 +1,2 @@
 # This is for travis to give us an appropriate version of virtualenv
-virtualenv==13.1.2
+virtualenv==15.0.1


### PR DESCRIPTION
This does a couple of things:
- Drops us trying to install virtualenv globally when it really should be done by the user (as it might require sudo or whatever) - but adds documentation for the dependency.
- Lists all the dependencies of the python packages, not just the ones we require.
- Update all packages to the latest
  - This also includes updating marionette for which it supplies a couple of new properties that would be useful.
