### PR TITLE
Bug 1261845 - Wrong background and tooltip for Hello icon during tour

### DIFF
--- a/add-on/chrome/bootstrap.js
+++ b/add-on/chrome/bootstrap.js
@@ -539,6 +539,7 @@ var WindowListener = {
           mozL10nId += "-error";
         } else if (this.isSlideshowOpen) {
           state = "slideshow";
+          suffix = ".label";
         } else if (this.MozLoopService.screenShareActive) {
           state = "action";
           mozL10nId += "-screensharing";
@@ -1383,11 +1384,11 @@ function startup(data) {
   // Load our stylesheets.
   let styleSheetService = Cc["@mozilla.org/content/style-sheet-service;1"]
     .getService(Components.interfaces.nsIStyleSheetService);
-  let sheets = ["chrome://loop-shared/skin/loop.css"];
+  let sheets = [
+    "chrome://loop-shared/skin/loop.css",
+    "chrome://loop/skin/platform.css"
+  ];
 
-  if (AppConstants.platform != "linux") {
-    sheets.push("chrome://loop/skin/platform.css");
-  }
 
   for (let sheet of sheets) {
     let styleSheetURI = Services.io.newURI(sheet, null, null);

--- a/add-on/chrome/skin/linux/platform.css
+++ b/add-on/chrome/skin/linux/platform.css
@@ -12,18 +12,6 @@
    * due to the limitations caused by the bug.
    */
 
-  @media (-moz-windows-theme: luna-silver) and (max-resolution: 1dppx) {
-    #loop-button {
-      list-style-image: url(chrome://loop/skin/toolbar-lunaSilver.png)
-    }
-  }
-
-  @media (-moz-windows-theme: luna-silver) and (min-resolution: 1.1dppx) {
-    #loop-button {
-      list-style-image: url(chrome://loop/skin/toolbar-lunaSilver@2x.png)
-    }
-  }
-
   #loop-button[state="slideshow"] {
     background: none;
   }


### PR DESCRIPTION
@Standard8  Added shared loop CSS for slideshow state on the toolbarbutton-badge-stack element.  There was no clear definition of CSS for the background on the icon for any platform so this may fix for all platforms.  Will need to test on all platforms as it works on Ubuntu 14.04 LTS.

Can this be retested by QA again to see if fixed?
