### PR TITLE
Turn on already-passing rules and enable some with few fixes.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,8 +48,10 @@
     "accessor-pairs": [2, {"setWithoutGet": true, "getWithoutSet": false}],
     "array-bracket-spacing": [2, "never"],
     "array-callback-return": 2,
+    "arrow-body-style": [2, "as-needed"],
     "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,
+    "block-scoped-var": 2,
     "block-spacing": [2, "always"],
     "callback-return": 0,         // TBD
     "camelcase": 0,               // TODO: set to 2
@@ -63,6 +65,7 @@
     "eol-last": 2,
     "eqeqeq": [2, "smart"],
     "generator-star-spacing": [2, "after"],
+    "guard-for-in": 2,
     "handle-callback-err": 2,
     "id-blacklist": 2,            // TBD pattern
     "id-match": 2,                // TBD pattern
@@ -72,6 +75,7 @@
     "linebreak-style": [2, "unix"],
     "max-depth": [2, 3],
     "max-nested-callbacks": [2, 3],
+    "max-statements-per-line": [2, {"max": 1}],
     "new-cap": 0,                 // TODO: set to 2
     "new-parens": 2,
     "no-alert": 2,
@@ -79,6 +83,7 @@
     "no-caller": 2,
     "no-catch-shadow": 2,
     "no-class-assign": 2,
+    "no-confusing-arrow": [2, {"allowParens": true}],
     "no-console": 0,              // Leave as 0. We use console logging in content code.
     "no-const-assign": 2,
     "no-div-regex": 2,
@@ -100,6 +105,7 @@
     "no-label-var": 2,
     "no-labels": 2,
     "no-lone-blocks": 2,
+    "no-lonely-if": 2,
     "no-loop-func": 2,
     "no-mixed-requires": 2,
     "no-mixed-spaces-and-tabs": 2,
@@ -127,6 +133,7 @@
     "no-shadow-restricted-names": 2,
     "no-spaced-func": 2,
     "no-sync": 2,
+    "no-throw-literal": 2,
     "no-trailing-spaces": 2,
     "no-undef-init": 2,
     "no-underscore-dangle": 0,    // Leave as 0. Commonly used for private variables.
@@ -139,12 +146,17 @@
     "no-use-before-define": 0,    // TODO: Set to 2
     "no-useless-call": 2,
     "no-useless-computed-key": 2,
+    "no-useless-concat": 2,
     "no-useless-constructor": 2,
+    "no-useless-escape": 2,
+    "no-void": 2,
     "no-whitespace-before-property": 2,
     "no-with": 2,
     "object-curly-spacing": [2, "always"],
+    "one-var-declaration-per-line": [2, "initializations"],
     "operator-assignment": [2, "always"],
     "quotes": [2, "double", "avoid-escape"],
+    "radix": [2, "always"],
     "require-yield": 2,
     "semi": 2,
     "semi-spacing": [2, {"before": false, "after": true}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,10 @@
     // problems they find, one at a time.
 
     // Eslint built-in rules are documented at <http://eslint.org/docs/rules/>
+    "accessor-pairs": [2, {"setWithoutGet": true, "getWithoutSet": false}],
     "array-bracket-spacing": [2, "never"],
+    "array-callback-return": 2,
+    "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,
     "block-spacing": [2, "always"],
     "callback-return": 0,         // TBD
@@ -54,15 +57,21 @@
     "comma-style": 2,
     "computed-property-spacing": [2, "never"],
     "consistent-return": 2,
+    "consistent-this": [2, "use-bind"],
     "curly": [2, "all"],
     "dot-location": [2, "property"],
     "eol-last": 2,
     "eqeqeq": [2, "smart"],
     "generator-star-spacing": [2, "after"],
+    "handle-callback-err": 2,
+    "id-blacklist": 2,            // TBD pattern
+    "id-match": 2,                // TBD pattern
     "jsx-quotes": [2, "prefer-double"],
-    "key-spacing": [2, {"beforeColon": false, "afterColon": true }],
+    "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": 2,
     "linebreak-style": [2, "unix"],
+    "max-depth": [2, 3],
+    "max-nested-callbacks": [2, 3],
     "new-cap": 0,                 // TODO: set to 2
     "new-parens": 2,
     "no-alert": 2,
@@ -70,16 +79,21 @@
     "no-caller": 2,
     "no-catch-shadow": 2,
     "no-class-assign": 2,
-    "no-const-assign": 2,
     "no-console": 0,              // Leave as 0. We use console logging in content code.
+    "no-const-assign": 2,
+    "no-div-regex": 2,
     "no-duplicate-case": 2,
+    "no-duplicate-imports": 2,
     "no-else-return": 2,
     "no-empty": 2,
+    "no-eq-null": 2,
     "no-eval": 2,
     "no-extend-native": 2, // XXX
     "no-extra-bind": 0,           // Leave as 0
+    "no-extra-label": 2,
     "no-extra-parens": 0,         // TODO: (bug?) [2, "functions"],
     "no-extra-semi": 2,
+    "no-floating-decimal": 2,
     "no-implied-eval": 2,
     "no-invalid-this": 0,         // TBD
     "no-iterator": 2,
@@ -87,6 +101,7 @@
     "no-labels": 2,
     "no-lone-blocks": 2,
     "no-loop-func": 2,
+    "no-mixed-requires": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-multi-spaces": 2,
     "no-multi-str": 2,
@@ -95,9 +110,15 @@
     "no-new": 2,
     "no-new-func": 2,
     "no-new-object": 2,
+    "no-new-require": 2,
     "no-new-wrappers": 2,
     "no-octal-escape": 2,
+    "no-path-concat": 2,
     "no-proto": 2,
+    "no-restricted-globals": 2,   // TBD pattern
+    "no-restricted-imports": 2,   // TBD pattern
+    "no-restricted-modules": 2,   // TBD pattern
+    "no-restricted-syntax": 2,    // TBD pattern
     "no-return-assign": 2,
     "no-script-url": 2,
     "no-self-compare": 2,
@@ -105,25 +126,33 @@
     "no-shadow": 2,
     "no-shadow-restricted-names": 2,
     "no-spaced-func": 2,
+    "no-sync": 2,
     "no-trailing-spaces": 2,
     "no-undef-init": 2,
     "no-underscore-dangle": 0,    // Leave as 0. Commonly used for private variables.
     "no-unexpected-multiline": 2,
+    "no-unmodified-loop-condition": 2,
     "no-unneeded-ternary": 2,
+    "no-unsafe-finally": 2,
     "no-unused-expressions": 0,   // TODO: Set to 2
     "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
     "no-use-before-define": 0,    // TODO: Set to 2
     "no-useless-call": 2,
+    "no-useless-computed-key": 2,
+    "no-useless-constructor": 2,
+    "no-whitespace-before-property": 2,
     "no-with": 2,
     "object-curly-spacing": [2, "always"],
     "operator-assignment": [2, "always"],
     "quotes": [2, "double", "avoid-escape"],
+    "require-yield": 2,
     "semi": 2,
     "semi-spacing": [2, {"before": false, "after": true}],
+    "sort-imports": 2,
     "space-before-blocks": 2,
     "space-before-function-paren": [2, "never"],
-    "space-infix-ops": 2,
     "space-in-parens": [2, "never"],
+    "space-infix-ops": [2, {"int32Hint": false}],
     "space-unary-ops": [2, {"words": true, "nonwords": false}],
     "spaced-comment": [2, "always"],
     "strict": [2, "function"],

--- a/add-on/chrome/modules/LoopRoomsCache.jsm
+++ b/add-on/chrome/modules/LoopRoomsCache.jsm
@@ -63,9 +63,8 @@ LoopRoomsCache.prototype = {
   _setCache: function(contents) {
     this._cache = contents;
 
-    return OS.File.makeDir(this.baseDir, { ignoreExisting: true }).then(() => {
-        return CommonUtils.writeJSON(contents, this.path);
-      });
+    return OS.File.makeDir(this.baseDir, { ignoreExisting: true }).then(() =>
+      CommonUtils.writeJSON(contents, this.path));
   },
 
   /**

--- a/add-on/chrome/modules/MozLoopPushHandler.jsm
+++ b/add-on/chrome/modules/MozLoopPushHandler.jsm
@@ -300,7 +300,7 @@ PingMonitor.prototype = {
   restart: function() {
     consoleLog.info("PushHandler: ping timeout restart");
     this.stop();
-    this._pingTimerID = setTimeout(() => { this._pingSend(); }, this._pingInterval);
+    this._pingTimerID = setTimeout(() => this._pingSend(), this._pingInterval);
   },
 
   /**

--- a/add-on/chrome/modules/MozLoopService.jsm
+++ b/add-on/chrome/modules/MozLoopService.jsm
@@ -676,13 +676,9 @@ var MozLoopServiceInternal = {
         if (retryOn401 && sessionType === LOOP_SESSION_TYPE.GUEST) {
           log.info("401 and INVALID_AUTH_TOKEN - retry registration");
           return this.registerWithLoopServer(sessionType, false).then(
-            () => {
-              return this.hawkRequestInternal(sessionType, path, method, payloadObj, false);
-            },
-            () => {
-              // Process the original error that triggered the retry.
-              return handle401Error(error);
-            }
+            () => this.hawkRequestInternal(sessionType, path, method, payloadObj, false),
+            // Process the original error that triggered the retry.
+            () => handle401Error(error)
           );
         }
         return handle401Error(error);
@@ -1266,10 +1262,8 @@ var MozLoopServiceInternal = {
       code: code,
       state: state
     };
-    return this.hawkRequestInternal(LOOP_SESSION_TYPE.FXA, "/fxa-oauth/token", "POST", payload).then(response => {
-      return JSON.parse(response.body);
-    },
-    error => { this._hawkRequestError(error); });
+    return this.hawkRequestInternal(LOOP_SESSION_TYPE.FXA, "/fxa-oauth/token", "POST", payload).then(
+      response => JSON.parse(response.body), error => this._hawkRequestError(error));
   },
 
   /**
@@ -1465,9 +1459,8 @@ this.MozLoopService = {
     }
 
     // Check that the room chatbox is still actually open using its URL
-    let chatboxesForRoom = [...Chat.chatboxes].filter(chatbox => {
-      return chatbox.src == MozLoopServiceInternal.getChatURL(room.roomToken);
-    });
+    let chatboxesForRoom = [...Chat.chatboxes].filter(chatbox =>
+      chatbox.src == MozLoopServiceInternal.getChatURL(room.roomToken));
 
     if (!chatboxesForRoom.length) {
       log.warn("Tried to resume the tour from a join when the chatbox was closed", room);
@@ -1804,9 +1797,9 @@ this.MozLoopService = {
     if (!forceReAuth && MozLoopServiceInternal.fxAOAuthTokenData) {
       return Promise.resolve(MozLoopServiceInternal.fxAOAuthTokenData);
     }
-    return MozLoopServiceInternal.promiseFxAOAuthAuthorization(forceReAuth).then(response => {
-      return MozLoopServiceInternal.promiseFxAOAuthToken(response.code, response.state);
-    }).then(tokenData => {
+    return MozLoopServiceInternal.promiseFxAOAuthAuthorization(forceReAuth).then(response =>
+      MozLoopServiceInternal.promiseFxAOAuthToken(response.code, response.state)
+    ).then(tokenData => {
       MozLoopServiceInternal.fxAOAuthTokenData = tokenData;
       return MozLoopServiceInternal.promiseRegisteredWithServers(LOOP_SESSION_TYPE.FXA).then(() => {
         MozLoopServiceInternal.clearError("login");
@@ -1921,9 +1914,9 @@ this.MozLoopService = {
   getTourURL: function(aSrc = null, aAdditionalParams = {}) {
     let urlStr = this.getLoopPref("gettingStarted.url");
     let url = new URL(Services.urlFormatter.formatURL(urlStr));
-    for (let paramName in aAdditionalParams) {
+    Object.keys(aAdditionalParams).forEach(paramName => {
       url.searchParams.set(paramName, aAdditionalParams[paramName]);
-    }
+    });
     if (aSrc) {
       url.searchParams.set("utm_source", "firefox-browser");
       url.searchParams.set("utm_medium", "firefox-browser");
@@ -2068,7 +2061,7 @@ this.MozLoopService = {
    */
   hawkRequest: function(sessionType, path, method, payloadObj) {
     return MozLoopServiceInternal.hawkRequest(sessionType, path, method, payloadObj).catch(
-      error => { MozLoopServiceInternal._hawkRequestError(error); });
+      error => MozLoopServiceInternal._hawkRequestError(error));
   },
 
   /**
@@ -2110,10 +2103,8 @@ this.MozLoopService = {
   setScreenShareState: function(windowId, active) {
     if (active) {
       this._activeScreenShares.add(windowId);
-    } else {
-      if (this._activeScreenShares.has(windowId)) {
-        this._activeScreenShares.delete(windowId);
-      }
+    } else if (this._activeScreenShares.has(windowId)) {
+      this._activeScreenShares.delete(windowId);
     }
 
     MozLoopServiceInternal.notifyStatusChanged();

--- a/add-on/chrome/test/mochitest/browser_LoopRooms_channel.js
+++ b/add-on/chrome/test/mochitest/browser_LoopRooms_channel.js
@@ -149,7 +149,7 @@ add_task(function* test_loopRooms_webchannel_openRoom() {
   // Check the room was opened.
   Assert.ok(openedUrl, "should open a chat window");
 
-  let windowId = openedUrl.match(/about:loopconversation\#(\w+)$/)[1];
+  let windowId = openedUrl.match(/about:loopconversation#(\w+)$/)[1];
   let windowData = MozLoopService.getConversationWindowData(windowId);
 
   Assert.equal(windowData.type, "room", "window data should contain room as the type");

--- a/add-on/chrome/test/mochitest/browser_copypanel.js
+++ b/add-on/chrome/test/mochitest/browser_copypanel.js
@@ -4,7 +4,7 @@
 "use strict";
 
 let gConstants;
-LoopAPI.inspect()[1].GetAllConstants({}, constants => { return (gConstants = constants); });
+LoopAPI.inspect()[1].GetAllConstants({}, constants => (gConstants = constants));
 
 let { goDoCommand, gURLBar } = window;
 

--- a/add-on/chrome/test/mochitest/browser_mozLoop_chat.js
+++ b/add-on/chrome/test/mochitest/browser_mozLoop_chat.js
@@ -21,9 +21,8 @@ add_task(function* test_mozLoop_openchat() {
   let windowId = yield LoopRooms.open("fake1234");
   Assert.ok(isAnyLoopChatOpen(), "chat window should have been opened");
 
-  let chatboxesForRoom = [...Chat.chatboxes].filter(chatbox => {
-    return chatbox.src == MozLoopServiceInternal.getChatURL(windowId);
-  });
+  let chatboxesForRoom = [...Chat.chatboxes].filter(chatbox =>
+    chatbox.src == MozLoopServiceInternal.getChatURL(windowId));
   Assert.strictEqual(chatboxesForRoom.length, 1, "Only one chatbox should be open");
 });
 

--- a/add-on/chrome/test/mochitest/browser_throttler.js
+++ b/add-on/chrome/test/mochitest/browser_throttler.js
@@ -33,7 +33,11 @@ LoopThrottler._dns = {
     gNumResolved++;
     Assert.strictEqual(host, THROTTLE_HOSTNAME, "should be using test host");
     Assert.strictEqual(flags, this.RESOLVE_DISABLE_IPV6, "should set disable ipv6 flag");
-    callback(null, { getNextAddrAsString() { return gTestIP; } }, 0);
+    callback(null, {
+      getNextAddrAsString() {
+        return gTestIP;
+      }
+    }, 0);
   }
 };
 

--- a/add-on/chrome/test/mochitest/head.js
+++ b/add-on/chrome/test/mochitest/head.js
@@ -96,7 +96,10 @@ function waitForCondition(condition, nextTest, errorMsg) {
     }
     tries++;
   }, 100);
-  var moveOn = function() { clearInterval(interval); nextTest(); };
+  var moveOn = function() {
+    clearInterval(interval);
+    nextTest();
+  };
 }
 
 function promiseWaitForCondition(aConditionFn) {
@@ -305,7 +308,7 @@ const mockDb = {
   },
   promise: function(method, ...params) {
     return new Promise((resolve, reject) => {
-      this[method](...params, (err, res) => err ? reject(err) : resolve(res));
+      this[method](...params, (err, res) => (err ? reject(err) : resolve(res)));
     });
   }
 };

--- a/add-on/chrome/test/xpcshell/test_looprooms.js
+++ b/add-on/chrome/test/xpcshell/test_looprooms.js
@@ -294,16 +294,14 @@ add_task(function* setup_server() {
       Assert.ok("context" in data, "should have context");
 
       res.write(JSON.stringify(kCreateRoomData));
+    } else if (req.queryString) {
+      let qs = parseQueryString(req.queryString);
+      let room = kRoomsResponses.get("_nxD4V4FflQ");
+      room.participants = kRoomUpdates[qs.version].participants;
+      room.deleted = kRoomUpdates[qs.version].deleted;
+      res.write(JSON.stringify([room]));
     } else {
-      if (req.queryString) {
-        let qs = parseQueryString(req.queryString);
-        let room = kRoomsResponses.get("_nxD4V4FflQ");
-        room.participants = kRoomUpdates[qs.version].participants;
-        room.deleted = kRoomUpdates[qs.version].deleted;
-        res.write(JSON.stringify([room]));
-      } else {
-        res.write(JSON.stringify([...kRoomsResponses.values()]));
-      }
+      res.write(JSON.stringify([...kRoomsResponses.values()]));
     }
 
     res.processAsync();
@@ -422,7 +420,7 @@ add_task(function* test_openRoom() {
   Assert.ok(openedUrl, "should open a chat window");
 
   // Stop the busy kicking in for following tests. (note: windowId can be 'fakeToken')
-  let windowId = openedUrl.match(/about:loopconversation\#(\w+)$/)[1];
+  let windowId = openedUrl.match(/about:loopconversation#(\w+)$/)[1];
   let windowData = MozLoopService.getConversationWindowData(windowId);
 
   Assert.equal(windowData.type, "room", "window data should contain room as the type");
@@ -601,11 +599,9 @@ add_task(function* test_updateRoom_domains() {
   Services.prefs.setBoolPref("loop.logDomains", true);
 
   let roomToken = "_nxD4V4FflQ";
-  let addContext = url => {
-    return LoopRooms.promise("update", roomToken, {
-      urls: [{ location: url }]
-    });
-  };
+  let addContext = url => LoopRooms.promise("update", roomToken, {
+    urls: [{ location: url }]
+  });
 
   // Make sure one domain context is counted.
   yield addContext("https://www.mozilla.org");

--- a/add-on/chrome/test/xpcshell/test_loopservice_hawk_errors.js
+++ b/add-on/chrome/test/xpcshell/test_loopservice_hawk_errors.js
@@ -22,7 +22,7 @@ function errorRequestHandler(request, response) {
   response.setStatusLine(null, responseCode, "Error");
   if (responseCode == 401) {
     response.write(JSON.stringify({
-      code: parseInt(responseCode),
+      code: parseInt(responseCode, 10),
       errno: INVALID_AUTH_TOKEN,
       error: "INVALID_AUTH_TOKEN",
       message: "INVALID_AUTH_TOKEN"

--- a/add-on/panels/js/roomStore.js
+++ b/add-on/panels/js/roomStore.js
@@ -44,9 +44,9 @@ loop.store = loop.store || {};
   function Room(values) {
     var validatedData = new loop.validate.Validator(roomSchema || {})
                                          .validate(values || {});
-    for (var prop in validatedData) {
+    Object.keys(validatedData).forEach(prop => {
       this[prop] = validatedData[prop];
-    }
+    });
   }
 
   loop.store.Room = Room;

--- a/add-on/panels/test/.eslintrc
+++ b/add-on/panels/test/.eslintrc
@@ -1,7 +1,3 @@
 {
-  "rules": {
-    // This is useful for some of the tests, e.g.
-    // expect(new Foo()).to.Throw(/error/)
-    "no-new": 0
-  }
+  "extends": "../../../test/.eslintrc"
 }

--- a/add-on/panels/test/feedbackViews_test.js
+++ b/add-on/panels/test/feedbackViews_test.js
@@ -22,8 +22,8 @@ describe("loop.feedbackViews", function() {
   });
 
   describe("FeedbackView", function() {
-    var openURLStub, getLoopPrefStub, feedbackReceivedStub;
-    var fakeURL = "fake.form", view;
+    var openURLStub, getLoopPrefStub, feedbackReceivedStub, view;
+    var fakeURL = "fake.form";
 
     function mountTestComponent(props) {
       props = _.extend({

--- a/add-on/panels/test/roomStore_test.js
+++ b/add-on/panels/test/roomStore_test.js
@@ -683,8 +683,12 @@ describe("loop.store.RoomStore", function() {
         }));
 
         sinon.assert.calledOnce(socialShareRoomStub);
-        sinon.assert.calledWithExactly(socialShareRoomStub, origin,
-          roomUrl, "share_email_subject7", "share_email_body7" + "share_email_footer2");
+        sinon.assert.calledWithExactly(socialShareRoomStub,
+          origin,
+          roomUrl,
+          "share_email_subject7",
+          "share_email_body7" +
+            "share_email_footer2");
       });
 
       it("should pass the correct data for all other Social Providers", function() {

--- a/bin/run-utils.js
+++ b/bin/run-utils.js
@@ -85,7 +85,7 @@ function isErrorString(line) {
 var GARBAGE = [
   /\[JavaScript Warning: "TypeError: "[\w\d]+" is read-only"\]/,
   /JavaScript strict warning: /,
-  /\#\#\#\!\!\! \[Child\]\[DispatchAsyncMessage\]/
+  /###!!! \[Child\]\[DispatchAsyncMessage\]/
 ];
 
 /**

--- a/bin/runfx.js
+++ b/bin/runfx.js
@@ -63,7 +63,7 @@ var profile = Commander.profile || DEFAULT_PROFILE;
 var extensionsDir, addonTargetDir;
 Fs.stat(addonSourceDir).then(function(sourceStat) {
   if (!sourceStat.isDirectory()) {
-    throw "Not a directory";
+    throw new Error("Not a directory");
   }
 }).catch(function(err) {
   onExit(err, "ERROR! Please run `make build` first!");

--- a/shared/js/actions.js
+++ b/shared/js/actions.js
@@ -17,9 +17,9 @@ loop.shared.actions = (function() {
   function Action(name, schema, values) {
     var validatedData = new loop.validate.Validator(schema || {})
                                          .validate(values || {});
-    for (var prop in validatedData) {
+    Object.keys(validatedData).forEach(function(prop) {
       this[prop] = validatedData[prop];
-    }
+    }.bind(this));
 
     this.name = name;
   }

--- a/shared/js/activeRoomStore.js
+++ b/shared/js/activeRoomStore.js
@@ -636,19 +636,17 @@ loop.store.ActiveRoomStore = (function(mozL10n) {
           // XXX Firefox didn't handle this, even though it said it could
           // previously. We should add better user feedback here.
           console.error("Firefox didn't handle room it said it could.");
+        } else if (e.detail.message.alreadyOpen) {
+          this.dispatcher.dispatch(new sharedActions.ConnectionFailure({
+            reason: FAILURE_DETAILS.ROOM_ALREADY_OPEN
+          }));
         } else {
-          if (e.detail.message.alreadyOpen) {
-            this.dispatcher.dispatch(new sharedActions.ConnectionFailure({
-              reason: FAILURE_DETAILS.ROOM_ALREADY_OPEN
-            }));
-          } else {
-            this.dispatcher.dispatch(new sharedActions.JoinedRoom({
-              apiKey: "",
-              sessionToken: "",
-              sessionId: "",
-              expires: 0
-            }));
-          }
+          this.dispatcher.dispatch(new sharedActions.JoinedRoom({
+            apiKey: "",
+            sessionToken: "",
+            sessionId: "",
+            expires: 0
+          }));
         }
       }
 

--- a/shared/js/otSdkDriver.js
+++ b/shared/js/otSdkDriver.js
@@ -726,7 +726,9 @@ loop.OTSdkDriver = (function() {
       ];
 
       dataChannels.forEach(function(args) {
-        var type = args[0], onMessage = args[1], onChannel = args[2];
+        var type = args[0],
+            onMessage = args[1],
+            onChannel = args[2];
         sdkSubscriberObject._.getDataChannel(type, {}, function(err, channel) {
           // Sends will queue until the channel is fully open.
           if (err) {
@@ -786,7 +788,8 @@ loop.OTSdkDriver = (function() {
 
       // This won't work until a subscriber exists for this publisher
       dataChannels.forEach(function(args) {
-        var type = args[0], onChannel = args[1];
+        var type = args[0],
+            onChannel = args[1];
         this.publisher._.getDataChannel(type, {}, function(err, channel) {
           if (err) {
             console.error(err);

--- a/shared/js/store.js
+++ b/shared/js/store.js
@@ -47,10 +47,10 @@ loop.store.createStore = (function() {
      * @param {Object} newState The new store state object.
      */
     setStoreState: function(newState) {
-      for (var key in newState) {
+      Object.keys(newState).forEach(function(key) {
         this._storeState[key] = newState[key];
         this.trigger("change:" + key);
-      }
+      }.bind(this));
       this.trigger("change");
     },
 

--- a/shared/js/utils.js
+++ b/shared/js/utils.js
@@ -249,13 +249,11 @@ if (inChrome) {
     platform = platform.toLowerCase().split(";");
     if (/macintosh/.test(platform[0]) || /x11/.test(platform[0])) {
       platform = platform[1];
+    } else if (platform[0].indexOf("win") > -1 && platform.length > 4) {
+      // Skip the security notation.
+      platform = platform[2];
     } else {
-      if (platform[0].indexOf("win") > -1 && platform.length > 4) {
-        // Skip the security notation.
-        platform = platform[2];
-      } else {
-        platform = platform[0];
-      }
+      platform = platform[0];
     }
 
     if (!withVersion) {
@@ -441,8 +439,9 @@ if (inChrome) {
     }
     // Bug 1196143 - formatURL sanitizes(decodes) the URL from IDN homographic attacks.
     // Try catch to not produce output if invalid url
+    var sanitizedURL;
     try {
-      var sanitizedURL = loop.shared.utils.formatURL(url, true);
+      sanitizedURL = loop.shared.utils.formatURL(url, true);
     } catch (ex) {
       return null;
     }

--- a/shared/test/.eslintrc
+++ b/shared/test/.eslintrc
@@ -1,10 +1,6 @@
 {
+  "extends": "../../test/.eslintrc",
   "globals": {
     "ReactDOMServer": false,
-  },
-  "rules": {
-    // This is useful for some of the tests, e.g.
-    // expect(new Foo()).to.Throw(/error/)
-    "no-new": 0
   }
 }

--- a/shared/test/utils_test.js
+++ b/shared/test/utils_test.js
@@ -376,14 +376,20 @@ describe("loop.shared.utils", function() {
 
       sinon.assert.calledOnce(requestStubs.ComposeEmail);
       sinon.assert.calledWith(requestStubs.ComposeEmail,
-                              "subject", "body" + "footer", "fake@invalid.tld");
+                              "subject",
+                              "body" +
+                                "footer",
+                              "fake@invalid.tld");
     });
 
     it("should compose a different email when context info is provided", function() {
       sharedUtils.composeCallUrlEmail("http://invalid", null, "Hello, is me you're looking for?");
 
       sinon.assert.calledOnce(requestStubs.ComposeEmail);
-      sinon.assert.calledWith(requestStubs.ComposeEmail, "subject", "body_context" + "footer");
+      sinon.assert.calledWith(requestStubs.ComposeEmail,
+                              "subject",
+                              "body_context" +
+                                "footer");
     });
   });
 
@@ -623,7 +629,7 @@ describe("loop.shared.utils", function() {
         prop1: null,
         prop2: false,
         prop3: undefined,
-        prop4: void 0,
+        prop4: void 0, // eslint-disable-line no-void
         prop5: "",
         prop6: 0
       };

--- a/standalone/content/js/standaloneRoomViews.jsx
+++ b/standalone/content/js/standaloneRoomViews.jsx
@@ -604,10 +604,8 @@ loop.standaloneRoomViews = (function(mozL10n) {
         if (this.props.introSeen) {
           introSeen = true;
         }
-      } else {
-        if (localStorage.getItem("introSeen") !== null) {
-          introSeen = true;
-        }
+      } else if (localStorage.getItem("introSeen") !== null) {
+        introSeen = true;
       }
       var storeState = this.props.activeRoomStore.getStoreState();
       return _.extend({}, storeState, {

--- a/standalone/test/.eslintrc
+++ b/standalone/test/.eslintrc
@@ -1,7 +1,3 @@
 {
-  "rules": {
-    // This is useful for some of the tests, e.g.
-    // expect(new Foo()).to.Throw(/error/)
-    "no-new": 0
-  }
+  "extends": "../../test/.eslintrc"
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,7 @@
 {
   "rules": {
+    // We want nesting of describe/it callbacks.
+    "max-nested-callbacks": 0,
     // This is useful for some of the tests, e.g.
     // expect(new Foo()).to.Throw(/error/)
     "no-new": 0


### PR DESCRIPTION
r?@Standard8

I've got the no-code-changed rule additions in the first commit. A bunch of separate commits to turn on individual rules after some fixes. I can squash the desired additional rules into a combined second commit and drop the others.
