### PR TITLE
Bug 1247894 - about:loop* update

### DIFF
--- a/add-on/chrome/.eslintrc
+++ b/add-on/chrome/.eslintrc
@@ -6,6 +6,7 @@
     // Bootstrap magic globals.
     "APP_SHUTDOWN": false,
     // Gecko + Loop Globals.
+    "AboutLoop": false,
     "AppConstants": false,
     "appInfo": false,
     "Chat": false,

--- a/add-on/chrome/modules/AboutLoop.jsm
+++ b/add-on/chrome/modules/AboutLoop.jsm
@@ -25,7 +25,7 @@ XPCOMUtils.defineLazyGetter(this, "log", () => {
 
 
 function AboutPage(chromeURL, aboutHost, classID, description, uriFlags) {
-this.chromeURL = chromeURL;
+  this.chromeURL = chromeURL;
   this.aboutHost = aboutHost;
   this.classID = Components.ID(classID);
   this.description = description;
@@ -45,7 +45,8 @@ AboutPage.prototype = {
     channel.originalURI = aURI;
 
     if (this.uriFlags & Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT) {
-      let principal = Services.scriptSecurityManager.getNoAppCodebasePrincipal(aURI);
+      let principal =
+        Services.scriptSecurityManager.getNoAppCodebasePrincipal(aURI);
       channel.owner = principal;
     }
     return channel;
@@ -83,10 +84,10 @@ XPCOMUtils.defineLazyGetter(AboutLoop, "conversation", () =>
                 "E79DB45D-2D6D-48BE-B179-6A16C95E97BA",
                 "About Loop Conversation",
                 Ci.nsIAboutModule.ALLOW_SCRIPT |
-                 Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
-                 Ci.nsIAboutModule.MAKE_UNLINKABLE |
-                 Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT |
-                 Ci.nsIAboutModule.URI_MUST_LOAD_IN_CHILD)
+                  Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
+                  Ci.nsIAboutModule.MAKE_UNLINKABLE |
+                  Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT |
+                  Ci.nsIAboutModule.URI_MUST_LOAD_IN_CHILD)
 );
 
 XPCOMUtils.defineLazyGetter(AboutLoop, "panel", () =>
@@ -95,9 +96,9 @@ XPCOMUtils.defineLazyGetter(AboutLoop, "panel", () =>
                 "A5DE152B-DE58-42BC-A68C-33E00B17EC2C",
                 "About Loop Panel",
                 Ci.nsIAboutModule.ALLOW_SCRIPT |
-                 Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
-                 Ci.nsIAboutModule.MAKE_UNLINKABLE |
-                 Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT)
+                  Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
+                  Ci.nsIAboutModule.MAKE_UNLINKABLE |
+                  Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT)
 );
 
 XPCOMUtils.defineLazyGetter(AboutLoop, "toc", () =>
@@ -106,9 +107,10 @@ XPCOMUtils.defineLazyGetter(AboutLoop, "toc", () =>
                 "A1220CE0-E5D1-45B6-BEBA-3706166A2AA4",
                 "About Loop ToC",
                 Ci.nsIAboutModule.ALLOW_SCRIPT |
-                 Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
-                 Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT |
-                 Ci.nsIAboutModule.MAKE_UNLINKABLE) // XXX akita-sidebar load in child?
+                  Ci.nsIAboutModule.HIDE_FROM_ABOUTABOUT |
+                  Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT |
+                  Ci.nsIAboutModule.MAKE_UNLINKABLE)
+                  // XXX akita-sidebar load in child?
 );
 
 this.EXPORTED_SYMBOLS = ["AboutLoop"];

--- a/add-on/chrome/modules/loop-content-process.js
+++ b/add-on/chrome/modules/loop-content-process.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+// This file is loaded as a process script, it will be loaded in the parent
+// process as well as all content processes.
+
+const { utils: Cu } = Components;
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("chrome://loop/content/modules/AboutLoop.jsm");
+
+function AboutLoopChildListener() {
+}
+AboutLoopChildListener.prototype = {
+  onStartup: function onStartup() {
+
+    // Only do this in content processes since, as the broadcaster of this
+    // message, the parent process doesn't also receive it.  We handlers
+    // the shutting down separately.
+    if (Services.appinfo.processType ==
+        Services.appinfo.PROCESS_TYPE_CONTENT) {
+
+      Services.cpmm.addMessageListener("LoopShuttingDown", this, true);
+    }
+
+    AboutLoop.conversation.register();
+    AboutLoop.panel.register();
+    AboutLoop.toc.register();
+  },
+
+  /**
+   * Shutdown handler for the child process only.  We handle unregistering
+   * the chrome equivalent of this in bootstrap.js.  Some of this could be
+   * pushed down into AboutLoop itself in order to DRY the code up and
+   * make the API less error-prone.
+   */
+  onShutdown: function onShutdown() {
+    AboutLoop.panel.unregister();
+    AboutLoop.conversation.unregister();
+    AboutLoop.toc.unregister();
+
+    Services.cpmm.removeMessageListener("LoopShuttingDown", this);
+    Cu.unload("chrome://loop/content/modules/AboutLoop.jsm");
+  },
+
+  receiveMessage: function receiveMessage(message) {
+    switch (message.name) {
+
+      case "LoopShuttingDown":
+        this.onShutdown();
+        break;
+
+      default:
+        break;
+    }
+
+    return;
+  }
+};
+
+const listener = new AboutLoopChildListener();
+listener.onStartup(); // This will run in both chrome and content processes

--- a/add-on/install.rdf.in
+++ b/add-on/install.rdf.in
@@ -11,6 +11,7 @@
     <em:bootstrap>true</em:bootstrap>
     <em:version>2.0.0alpha@LOOP_XPI_DATE@</em:version>
     <em:type>2</em:type>
+    <em:multiprocessCompatible>true</em:multiprocessCompatible>
 
     <!-- Target Application this extension can install into,
          with minimum and maximum supported versions. -->


### PR DESCRIPTION
This PR attempts to back out the old version of the about:loop branch from the akita patch, and land the most up-to-date version.  There's at least one problem where the sidebar doesn't load that needs to be tracked down, plus some manual testing to make sure nothing else got broken is necessary.
