### PR TITLE
Follow-up to bug 1262441 - Add back the string that's used on the standalone infobar.

### DIFF
--- a/locale/en-US/standalone.properties
+++ b/locale/en-US/standalone.properties
@@ -31,6 +31,9 @@ intro_slide_copy=You’ll be able to see the page they shared with you and even 
 intro_slide_button=OK, got it!
 
 rooms_default_room_name_template=Conversation {{conversationLabel}}
+## LOCALIZATION_NOTE(rooms_welcome_title): {{conversationName}} will be replaced
+## by the user specified conversation name.
+rooms_welcome_title=Welcome to {{conversationName}}
 rooms_only_occupant_label2=You’re the only one here.
 room_owner_left_label=Your friend has left.
 room_user_left_label=You have disconnected.


### PR DESCRIPTION
In reviewing & testing Chris' string detection patch, I realised that we're missing the welcome string. Although this doesn't cause an error for standalone, it does blank the infobar when we shouldn't be.

This adds the string back for now.
