### PR TITLE
Bug 1273501 - create thumbnail from screenshot of current state of a url. r=fcampo

### DIFF
--- a/shared/js/actions.js
+++ b/shared/js/actions.js
@@ -160,17 +160,17 @@ loop.shared.actions = (function() {
     /**
      * Used to add a page to the current room
      */
+     // XXX akita: Update actions when metadata extraction bug is landed (Bug 1273497)
     AddPage: Action.define("addPage", {
-      description: String,
-      favicon_url: String,
-      images: Object,
       title: String,
+      thumbnail_img: String,
       url: String
     }),
 
     /**
      * Notifies that a tile has been received from the other peer.
      */
+    // XXX akita rename for readability
     AddedPage: Action.define("addedPage", {
       pageId: String,
       title: String,
@@ -188,6 +188,7 @@ loop.shared.actions = (function() {
     /**
     * Notifies that a tile has been removed.
      */
+    // XXX akita rename for readability
     DeletedPage: Action.define("deletedPage", {
       deletedTime: Number,
       pageId: String

--- a/shared/js/pageStore.js
+++ b/shared/js/pageStore.js
@@ -49,12 +49,11 @@ loop.store.PageStore = function() {
     /**
      * Handle AddPage action by saving the specific page.
      */
+     // XXX akita: Update data saved into Firebase according to the action `AddPage`
     addPage(actionData) {
       this._dataDriver.addPage({
-        description: actionData.description,
-        favicon_url: actionData.favicon_url,
-        images: actionData.images,
         title: actionData.title,
+        thumbnail_img: actionData.thumbnail_img,
         url: actionData.url,
         userName: this._currentUserName
       });
@@ -65,11 +64,9 @@ loop.store.PageStore = function() {
      */
     addedPage(actionData) {
       let page = {
-        description: actionData.description,
-        favicon_url: actionData.favicon_url,
         id: actionData.pageId,
-        images: actionData.images,
         title: actionData.title,
+        thumbnail_img: actionData.thumbnail_img,
         url: actionData.url,
         userName: actionData.userName
       };

--- a/shared/js/toc.jsx
+++ b/shared/js/toc.jsx
@@ -50,6 +50,21 @@ loop.shared.toc = (function(mozL10n) {
     componentWillUnmount() {
       this.props.pageStore.off("change", null, this);
     },
+    /**
+     * Adds a new tile to the ToC
+     */
+    addTile: function(metadata) {
+      var tiles = this.state.tiles;
+      tiles.push({
+        location: metadata.url,
+        description: metadata.description,
+        thumbnail_img: metadata.thumbnail_img
+      });
+
+      this.setState({
+        tiles: tiles
+      });
+    },
 
     render: function() {
       var cssClasses = classNames({

--- a/shared/js/toc.jsx
+++ b/shared/js/toc.jsx
@@ -243,7 +243,8 @@ loop.shared.toc = (function(mozL10n) {
           label: mozL10n.get("snackbar_page_added")
         }));
         this.props.handleAddUrlClick(result);
-      }).catch(() => {
+      }).catch((error) => {
+        console.error("getPageMetadata or thenable rejection: ", error);
         this.props.dispatcher.dispatch(new sharedActions.ShowSnackbar({
           label: mozL10n.get("snackbar_page_not_added")
         }));

--- a/shared/js/toc.jsx
+++ b/shared/js/toc.jsx
@@ -287,15 +287,15 @@ loop.shared.toc = (function(mozL10n) {
           <div className="room-user" data-name={this.props.page.userName}>
             <span>{this.props.page.userName[0].toUpperCase()}</span>
           </div>
-          <img className="tile-screenshot" src="" />
+          <img className="tile-screenshot" src={this.props.tile.thumbnail_img} />
           <div className="tile-info">
             <a
               className="tile-name"
               href={this.props.page.url}
               rel="noopener noreferrer"
               target="_blank"
-              title={this.props.page.description}>
-                {this.props.page.title}
+              title={this.props.tile.title}>
+                {this.props.tile.title}
             </a>
             <h3 className="tile-url">{this.props.page.url}</h3>
           </div>

--- a/shared/js/toc.jsx
+++ b/shared/js/toc.jsx
@@ -238,13 +238,21 @@ loop.shared.toc = (function(mozL10n) {
         return;
       }
 
+      // XXX akita: Code below is just for testing purpose
+      var btn = this.refs.addSiteBtn;
+      btn.textContent = "Loading...";
+      btn.disabled = true;
+
       loop.shared.utils.getPageMetadata(url).then(result => {
         this.props.dispatcher.dispatch(new sharedActions.ShowSnackbar({
           label: mozL10n.get("snackbar_page_added")
         }));
         this.props.handleAddUrlClick(result);
-      }).catch((error) => {
-        console.error("getPageMetadata or thenable rejection: ", error);
+      }).catch(() => {
+        // XXX akita: Code below is just for testing purpose
+        btn.textContent = "Add site";
+        btn.disabled = false;
+
         this.props.dispatcher.dispatch(new sharedActions.ShowSnackbar({
           label: mozL10n.get("snackbar_page_not_added")
         }));
@@ -256,7 +264,7 @@ loop.shared.toc = (function(mozL10n) {
         <div className="room-panel-add-url">
           <h2>{'Add a site to the room'}</h2>
           <input placeholder="http://..." ref="siteUrl" type="text" />
-          <button onClick={this.handleClick}>{'Add site'}</button>
+          <button onClick={this.handleClick} ref="addSiteBtn">{'Add site'}</button>
         </div>
       );
     }
@@ -303,15 +311,15 @@ loop.shared.toc = (function(mozL10n) {
           <div className="room-user" data-name={this.props.page.userName}>
             <span>{this.props.page.userName[0].toUpperCase()}</span>
           </div>
-          <img className="tile-screenshot" src={this.props.tile.thumbnail_img} />
+          <img className="tile-screenshot" src={this.props.page.thumbnail_img} />
           <div className="tile-info">
             <a
               className="tile-name"
               href={this.props.page.url}
               rel="noopener noreferrer"
               target="_blank"
-              title={this.props.tile.title}>
-                {this.props.tile.title}
+              title={this.props.page.title}>
+                {this.props.page.title}
             </a>
             <h3 className="tile-url">{this.props.page.url}</h3>
           </div>

--- a/shared/js/utils.js
+++ b/shared/js/utils.js
@@ -21,8 +21,6 @@ if (inChrome) {
   }
 }
 
-const API_KEY = "b0bbaba8774f4134b503644bfac12acd";
-
 (function() {
   "use strict";
 
@@ -815,34 +813,27 @@ const API_KEY = "b0bbaba8774f4134b503644bfac12acd";
   }
 
   function getPageMetadata(url) {
-    console.log("url", url);
     return new Promise((resolve, reject) => {
       let result = { url };
       let request = new XMLHttpRequest();
       request.open("GET",
         "https://www.googleapis.com/pagespeedonline/v1/runPagespeed?screenshot=true&strategy=desktop&url=" + encodeURIComponent(url));  // &key=${encodeURIComponent(API_KEY)}
       request.onload = () => {
-        console.log("request: ", request);
         if (request.status !== 200) {
           reject(request);
           return;
         }
         let extracted = JSON.parse(request.response);
         result.url = extracted.id;
-        // result.description = extracted.description;   //does not exist in response
         result.title = extracted.title;
-        // result.images = extracted.images;
-        // result.favicon_url = extracted.favicon_url;
 
         var screenshot = extracted.screenshot;
-        console.log("screenshot: ", screenshot);
         var src = "data:" + screenshot.mime_type + ";base64,";
         var base64 = screenshot.data;
-        base64 = base64.replace(/\_/g, "/");
+        base64 = base64.replace(/_/g, "/");
         base64 = base64.replace(/\-/g, "+");
         src += base64;
         result.thumbnail_img = src;
-        console.log("result: ", result);
         resolve(result);
       };
 

--- a/shared/js/utils.js
+++ b/shared/js/utils.js
@@ -815,23 +815,34 @@ const API_KEY = "b0bbaba8774f4134b503644bfac12acd";
   }
 
   function getPageMetadata(url) {
+    console.log("url", url);
     return new Promise((resolve, reject) => {
       let result = { url };
       let request = new XMLHttpRequest();
       request.open("GET",
-        `https://api.embedly.com/1/extract?url=${encodeURIComponent(url)}&key=${encodeURIComponent(API_KEY)}`);
+        "https://www.googleapis.com/pagespeedonline/v1/runPagespeed?screenshot=true&strategy=desktop&url=" + encodeURIComponent(url));  // &key=${encodeURIComponent(API_KEY)}
       request.onload = () => {
+        console.log("request: ", request);
         if (request.status !== 200) {
           reject(request);
           return;
         }
-
-        let extracted = JSON.parse(request.responseText);
-        result.url = extracted.provider_url;
-        result.description = extracted.description || "";
+        let extracted = JSON.parse(request.response);
+        result.url = extracted.id;
+        // result.description = extracted.description;   //does not exist in response
         result.title = extracted.title;
-        result.images = extracted.images;
-        result.favicon_url = extracted.favicon_url;
+        // result.images = extracted.images;
+        // result.favicon_url = extracted.favicon_url;
+
+        var screenshot = extracted.screenshot;
+        console.log("screenshot: ", screenshot);
+        var src = "data:" + screenshot.mime_type + ";base64,";
+        var base64 = screenshot.data;
+        base64 = base64.replace(/\_/g, "/");
+        base64 = base64.replace(/\-/g, "+");
+        src += base64;
+        result.thumbnail_img = src;
+        console.log("result: ", result);
         resolve(result);
       };
 

--- a/shared/test/pageStore_test.js
+++ b/shared/test/pageStore_test.js
@@ -56,12 +56,8 @@ describe("loop.store.PageStore", () => {
 
     it("should include the user name in page data", () => {
       let metadata = {
-        description: "fakeDescription",
-        favicon_url: "fakeFavicon",
-        images: [{
-          url: "fakeUrl"
-        }],
         title: "fakeTitle",
+        thumbnail_img: "fakeThumbnail",
         url: "fakeUrl"
       };
       let action = new actions.AddPage(metadata);
@@ -76,13 +72,9 @@ describe("loop.store.PageStore", () => {
   describe("AddedPage", () => {
     it("should add a page to the store", () => {
       let action = new actions.AddedPage({
-        description: "fakeDescription",
-        favicon_url: "fakeFavicon",
-        images: [{
-          url: "fakeUrl"
-        }],
         pageId: "fakeId",
         title: "fakeTitle",
+        thumbnail_img: "fakeThumbnail",
         url: "fakeUrl",
         userName: "fake user"
       });
@@ -108,13 +100,9 @@ describe("loop.store.PageStore", () => {
     beforeEach(() => {
       let pages = store.getStoreState("pages");
       pages.push({
-        description: "fakeDescription",
-        favicon_url: "fakeFavicon",
         id: "fakeId",
-        images: [{
-          url: "fakeUrl"
-        }],
         title: "fakeTitle",
+        thumbnail_img: "fakeThumbnail",
         url: "fakeUrl",
         userName: "fake user"
       });


### PR DESCRIPTION
Since https://github.com/mozilla/loop/pull/494 isn't writable, I forked it.  And, it should be writable by everyone on the team, I think/hope, so this PR will supercede that one.

After the first of these commits, things worked nicely.  

Then I rebased against the latest akita, added the second commit, and now it's broken because the metadata fields in getPageMetadata no longer match the ones that the action and the pageStore expect.  That should be easy to fix up, though.

After that, I think this wants a bit of basic cleanup along with some XXXakita love, as well as possible test tweaks, and we'll have the functionality working for URLs added by the + button.

I've started work based on top of the not-yet-rebased version of this patch over in bug 1274416 to make the initial URL get the metadata used properly as well.

CC @mancas, @crafuse, @fernando, @Standard8, @ianb 

I think anyone in the european timezone who wants to take this bug and run with it should feel free.
