### PR TITLE
Bug 1278032 - Display chat tile when a page is removed

### DIFF
--- a/bin/stringsCompletenessTest.py
+++ b/bin/stringsCompletenessTest.py
@@ -22,7 +22,7 @@ import glob
 import re
 import sys
 
-NOT_USED_EXPECTED_AMOUNT = 10
+NOT_USED_EXPECTED_AMOUNT = 12
 
 DEFAULT_PROPERTY_LOCALE = "en-US"
 

--- a/locale/en-US/shared.properties
+++ b/locale/en-US/shared.properties
@@ -8,6 +8,7 @@
 chat_textbox_placeholder=Type here…
 ## LOCALIZATION NOTE(username): The username can be 'You' when referring to self.
 chat_added_page_tile={{username}} added a site
+chat_deleted_page_tile={{username}} deleted a site
 
 ## LOCALIZATION NOTE(clientShortname2): This should not be localized and
 ## should remain "Firefox Hello" for all locales.

--- a/shared/css/sidebar.css
+++ b/shared/css/sidebar.css
@@ -285,6 +285,7 @@ html[dir="rtl"] .media-control-buttons .btn-hangup:after {
 }
 
 .text-chat-view > .text-chat-entries {
+  background: #f9f9f9;
   width: 100%;
   overflow: auto;
   padding-top: 15px;
@@ -534,6 +535,39 @@ html[dir="rtl"] .text-chat-entry.received .speech-bubble-arrow {
   margin-right: 0;
   margin-left: -10px;
 }
+
+/* Tile events */
+.tile-event {
+  width: 100%;
+  min-height: 70px;
+  padding: 5px 0;
+  text-align: center;
+}
+
+.tile-event > .context-wrapper {
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+  margin: 5px 10px;
+  text-align: left;
+  padding: 5px 10px;
+  line-height: 20px;
+}
+
+.deleted-tile .context-wrapper {
+  background: #fcf1f0;
+  border: 1px solid #d31612;
+}
+
+.tile-event .context-info {
+  color: #666666;
+}
+
+.tile-event .context-url {
+  color: #b0b0b0;
+}
+/* end tile events */
+
 
 /* Context updated */
 .text-chat-entry > .context-content > .context-wrapper {

--- a/shared/js/actions.js
+++ b/shared/js/actions.js
@@ -116,7 +116,7 @@ loop.shared.actions = (function() {
     SendTextChatMessage: Action.define("sendTextChatMessage", {
       contentType: String,
       message: String,
-      sentTimestamp: String
+      sentTimestamp: Number
     }),
 
     /**
@@ -127,8 +127,8 @@ loop.shared.actions = (function() {
       message: String,
       // XXX (optional because we don't use this for tiles.  Should refactor)
       // displayName: String,
-      receivedTimestamp: String
-      // sentTimestamp: String (optional)
+      receivedTimestamp: Number
+      // sentTimestamp: Number (optional)
     }),
 
     /**
@@ -173,9 +173,14 @@ loop.shared.actions = (function() {
     // XXX akita rename for readability
     AddedPage: Action.define("addedPage", {
       pageId: String,
-      title: String,
-      url: String
-      // metadata: Object (optional)
+      added_by: String,
+      added_time: Number,
+      metadata: Object
+      // {
+      //   title: String,
+      //   thumbnail_img: String,
+      //   url: String
+      // }
     }),
 
     /**
@@ -190,8 +195,20 @@ loop.shared.actions = (function() {
      */
     // XXX akita rename for readability
     DeletedPage: Action.define("deletedPage", {
-      deletedTime: Number,
-      pageId: String
+      pageId: String,
+      added_by: String,
+      added_time: Number,
+      metadata: Object,
+      // {
+      //   title: String,
+      //   thumbnail_img: String,
+      //   url: String
+      // }
+      deleted: Object
+      // {
+      //   deleted_by: String
+      //   deletion_time: Number
+      // }
     }),
 
     /**
@@ -435,7 +452,7 @@ loop.shared.actions = (function() {
       // newRoomDescription: String, Optional.
       // newRoomThumbnail: String, Optional.
       // newRoomURL: String Optional.
-      // sentTimestamp: String, Optional.
+      // sentTimestamp: Number, Optional.
     }),
 
     /**

--- a/shared/js/textChatView.jsx
+++ b/shared/js/textChatView.jsx
@@ -29,7 +29,7 @@ loop.shared.views.chat = (function(mozL10n) {
       extraData: React.PropTypes.object,
       message: React.PropTypes.string.isRequired,
       showTimestamp: React.PropTypes.bool.isRequired,
-      timestamp: React.PropTypes.string.isRequired,
+      timestamp: React.PropTypes.number.isRequired,
       type: React.PropTypes.string.isRequired
     },
 
@@ -56,6 +56,8 @@ loop.shared.views.chat = (function(mozL10n) {
         "received": this.props.type === CHAT_MESSAGE_TYPES.RECEIVED,
         "sent": this.props.type === CHAT_MESSAGE_TYPES.SENT,
         "special": this.props.type === CHAT_MESSAGE_TYPES.SPECIAL,
+        "added-tile": this.props.type === CHAT_MESSAGE_TYPES.ADDED,
+        "deleted-tile": this.props.type === CHAT_MESSAGE_TYPES.DELETED,
         "text-chat-notif": this.props.contentType === CHAT_CONTENT_TYPES.NOTIFICATION
       });
 
@@ -95,12 +97,14 @@ loop.shared.views.chat = (function(mozL10n) {
           <div className={classes}>
             <sharedViews.ChatPageTileView
               allowClick={true}
-              description={this.props.extraData.tile_title}
               dispatcher={this.props.dispatcher}
+              eventType={this.props.message}
               thumbnail={this.props.extraData.tile_thumbnail}
+              timestamp={this.props.showTimestamp ?
+                          this.props.timestamp : null}
+              title={this.props.extraData.tile_title}
               url={this.props.extraData.tile_url}
               username={this.props.displayName} />
-            {this.props.showTimestamp ? this._renderTimestamp() : null}
           </div>
         );
       }
@@ -258,7 +262,9 @@ loop.shared.views.chat = (function(mozL10n) {
                 }
 
                 /* For SENT messages there is no received timestamp. */
-                var timestamp = entry.receivedTimestamp || entry.sentTimestamp;
+                var timestamp = entry.receivedTimestamp ||
+                                entry.sentTimestamp ||
+                                entry.timestamp;
 
                 var timeDiff = this._isOneMinDelta(timestamp, lastTimestamp);
                 var shouldShowTimestamp = this._shouldShowTimestamp(i,
@@ -395,7 +401,7 @@ loop.shared.views.chat = (function(mozL10n) {
       this.props.dispatcher.dispatch(new sharedActions.SendTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: this.state.messageDetail,
-        sentTimestamp: (new Date()).toISOString()
+        sentTimestamp: Date.now()
       }));
 
       // Reset the form to empty, ready for the next message.

--- a/shared/js/toc.jsx
+++ b/shared/js/toc.jsx
@@ -324,8 +324,8 @@ loop.shared.toc = (function(mozL10n) {
               </div>
               <div className="tile-footer">
                 <h3 className="tile-url">{this.props.page.url}</h3>
-                <div className="tile-creator" data-name={this.props.page.userName}>
-                  <span>{this.props.page.userName[0].toUpperCase()}</span>
+                <div className="tile-creator" data-name={this.props.page.username}>
+                  <span>{this.props.page.username[0].toUpperCase()}</span>
                 </div>
               </div>
             </div>

--- a/shared/js/views.jsx
+++ b/shared/js/views.jsx
@@ -657,19 +657,21 @@ loop.shared.views = (function(_, mozL10n) {
 
     propTypes: {
       allowClick: React.PropTypes.bool.isRequired,
-      description: React.PropTypes.string,
       dispatcher: React.PropTypes.instanceOf(loop.Dispatcher),
+      eventType: React.PropTypes.string.isRequired,
       thumbnail: React.PropTypes.string,
+      timestamp: React.PropTypes.number,
+      title: React.PropTypes.string,
       url: React.PropTypes.string,
       username: React.PropTypes.string
     },
 
     getDefaultProps: function() {
       return {
-        description: null,
-        thumbnail: null,
-        url: null,
-        username: null
+        thumbnail: "shared/img/icons-16x16.svg#globe",
+        title: "WEB_TILE",
+        url: "WEB_URL",
+        username: "DEFAULT_USER"
       };
     },
 
@@ -687,23 +689,33 @@ loop.shared.views = (function(_, mozL10n) {
     },
 
     render: function() {
-      var description = this.props.description;
-      var thumbnail = this.props.thumbnail ||
-                      "shared/img/icons-16x16.svg#globe";
       var url = this.props.url;
       var username = this.props.username;
       var sanitizedURL = loop.shared.utils.formatSanitizedContextURL(url) || {};
-
+      var date = this.props.timestamp ?
+                  new Date(this.props.timestamp) :
+                  null;
       return (
-        <div className="context-content">
-          <p>{mozL10n.get("chat_added_page_tile", { username: username })}</p>
+        <div className="tile-event">
+          <p>{mozL10n.get(this.props.eventType, { username: username })}
+            {
+              date ?
+              <span className="text-chat-entry-timestamp">
+                {date.toLocaleTimeString(mozL10n.language.code, {
+                                          hour: "numeric",
+                                          minute: "numeric",
+                                          hour12: false
+                                        })}
+              </span> : null
+            }
+          </p>
           <ContextUrlLink allowClick={this.props.allowClick}
-                          description={description}
+                          description={this.props.title}
                           handleClick={this.handleLinkClick}
                           url={url}>
-            <img className="context-preview" src={thumbnail} />
+            <img className="context-preview" src={this.props.thumbnail} />
             <span className="context-info">
-              {description}
+              {this.props.title}
               <span className="context-url">
                 {sanitizedURL.hostname}
               </span>

--- a/shared/test/activeRoomStore_test.js
+++ b/shared/test/activeRoomStore_test.js
@@ -1446,7 +1446,7 @@ describe("loop.store.ActiveRoomStore", function() {
       store._handleTextChatMessage(new sharedActions.SendTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Hello!",
-        sentTimestamp: "1970-01-01T00:00:00.000Z"
+        sentTimestamp: 1401318000000
       }));
 
       assertWeDidNothing();
@@ -1458,7 +1458,7 @@ describe("loop.store.ActiveRoomStore", function() {
       store._handleTextChatMessage(new sharedActions.ReceivedTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Hello!",
-        receivedTimestamp: "1970-01-01T00:00:00.000Z"
+        receivedTimestamp: 1401318000000
       }));
 
       sinon.assert.notCalled(requestStubs.TelemetryAddValue);
@@ -1468,7 +1468,7 @@ describe("loop.store.ActiveRoomStore", function() {
       store._handleTextChatMessage(new sharedActions.SendTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.CONTEXT,
         message: "Hello!",
-        sentTimestamp: "1970-01-01T00:00:00.000Z"
+        sentTimestamp: 1401318000000
       }));
 
       assertWeDidNothing();

--- a/shared/test/textChatView_test.js
+++ b/shared/test/textChatView_test.js
@@ -110,7 +110,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }]
       });
 
@@ -128,7 +128,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.SENT,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Is it me you're looking for?",
-          sentTimestamp: "2015-06-25T17:53:55.357Z"
+          sentTimestamp: 1435254835357
         }]
       });
 
@@ -151,7 +151,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }]
       });
 
@@ -173,7 +173,7 @@ describe("loop.shared.views.TextChatView", function() {
             location: "http://wonderful.invalid",
             thumbnail: "fake"
           },
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }]
       });
 
@@ -191,7 +191,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.SENT,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          sentTimestamp: "2015-06-25T17:53:55.357Z"
+          sentTimestamp: 1435254835357
         }]
       });
 
@@ -205,12 +205,12 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }, {
           type: CHAT_MESSAGE_TYPES.SENT,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Is it me you're looking for?",
-          sentTimestamp: "2015-06-25T17:53:55.357Z"
+          sentTimestamp: 1435254835357
         }]
       });
       node = ReactDOM.findDOMNode(view);
@@ -227,12 +227,12 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.SENT,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          sentTimestamp: "2015-06-25T17:53:55.357Z"
+          sentTimestamp: 1435254835357
         }, {
           type: CHAT_MESSAGE_TYPES.SENT,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Is it me you're looking for?",
-          sentTimestamp: "2015-06-25T17:54:55.357Z"
+          sentTimestamp: 1435254835357
         }]
       });
       node = ReactDOM.findDOMNode(view);
@@ -247,12 +247,12 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }, {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Is it me you're looking for?",
-          receivedTimestamp: "2015-06-25T17:54:55.357Z"
+          receivedTimestamp: 1435254895357
         }]
       });
       node = ReactDOM.findDOMNode(view);
@@ -267,12 +267,12 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }, {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Is it me you're looking for?",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }]
       });
       node = ReactDOM.findDOMNode(view);
@@ -302,7 +302,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }];
 
         view.componentWillReceiveProps({ messageList: messageList });
@@ -317,7 +317,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.NOTIFICATION,
           message: "Bye!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }];
 
         view.componentWillReceiveProps({ messageList: messageList });
@@ -336,7 +336,7 @@ describe("loop.shared.views.TextChatView", function() {
             roomToken: "fake",
             newRoomURL: "http://marvelous.invalid"
           },
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }];
 
         view.componentWillReceiveProps({ messageList: messageList });
@@ -383,7 +383,7 @@ describe("loop.shared.views.TextChatView", function() {
             type: CHAT_MESSAGE_TYPES.RECEIVED,
             contentType: CHAT_CONTENT_TYPES.TEXT,
             message: "Hello!",
-            receivedTimestamp: "2015-06-25T17:53:55.357Z"
+            receivedTimestamp: 1435254835357
           }
         ];
 
@@ -402,7 +402,7 @@ describe("loop.shared.views.TextChatView", function() {
           type: CHAT_MESSAGE_TYPES.RECEIVED,
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          receivedTimestamp: "2015-06-25T17:53:55.357Z"
+          receivedTimestamp: 1435254835357
         }];
 
         view.componentWillReceiveProps({ messageList: messageList });
@@ -415,7 +415,7 @@ describe("loop.shared.views.TextChatView", function() {
             type: CHAT_MESSAGE_TYPES.RECEIVED,
             contentType: CHAT_CONTENT_TYPES.TEXT,
             message: "Hello!",
-            receivedTimestamp: "2015-06-25T17:53:55.357Z"
+            receivedTimestamp: 1435254835357
           }
         ];
 
@@ -435,7 +435,7 @@ describe("loop.shared.views.TextChatView", function() {
         dispatcher: dispatcher,
         message: "test",
         type: CHAT_MESSAGE_TYPES.RECEIVED,
-        timestamp: "2015-06-23T22:48:39.738Z"
+        timestamp: 1435254835357
       }, extraProps);
       return TestUtils.renderIntoDocument(
         React.createElement(loop.shared.views.chat.TextChatEntry, props));
@@ -444,7 +444,7 @@ describe("loop.shared.views.TextChatView", function() {
     it("should not render a timestamp", function() {
       view = mountTestComponent({
         showTimestamp: false,
-        timestamp: "2015-06-23T22:48:39.738Z",
+        timestamp: 1435254835357,
         type: CHAT_MESSAGE_TYPES.RECEIVED,
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "foo"
@@ -457,7 +457,7 @@ describe("loop.shared.views.TextChatView", function() {
     it("should render a timestamp", function() {
       view = mountTestComponent({
         showTimestamp: true,
-        timestamp: "2015-06-23T22:48:39.738Z",
+        timestamp: 1435254835357,
         type: CHAT_MESSAGE_TYPES.RECEIVED,
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "foo"
@@ -472,7 +472,7 @@ describe("loop.shared.views.TextChatView", function() {
     it("should linkify a URL starting with http", function() {
       view = mountTestComponent({
         showTimestamp: true,
-        timestamp: "2015-06-23T22:48:39.738Z",
+        timestamp: 1435254835357,
         type: CHAT_MESSAGE_TYPES.RECEIVED,
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Check out http://example.com and see what you think..."
@@ -501,10 +501,12 @@ describe("loop.shared.views.TextChatView", function() {
       // Fake server to catch all XHR requests.
       fakeServer = sinon.fakeServer.create();
       store.setStoreState({ textChatEnabled: true });
+      clock.tick(1435254895357); // "2015-06-25T17:54:55.357Z"
     });
 
     afterEach(function() {
       fakeServer.restore();
+      clock.restore();
     });
 
     it("should add a disabled class when text chat is disabled", function() {
@@ -534,8 +536,8 @@ describe("loop.shared.views.TextChatView", function() {
       store.receivedTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Hello!",
-        sentTimestamp: "1970-01-01T00:02:00.000Z",
-        receivedTimestamp: "1970-01-01T00:02:00.000Z"
+        sentTimestamp: 1401318000000,
+        receivedTimestamp: 1401318000000
       });
 
       expect(ReactDOM.findDOMNode(view).classList.contains("text-chat-entries-empty")).eql(false);
@@ -550,14 +552,14 @@ describe("loop.shared.views.TextChatView", function() {
       store.receivedTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Hello!",
-        sentTimestamp: "1970-01-01T00:03:00.000Z",
-        receivedTimestamp: "1970-01-01T00:03:00.000Z"
+        sentTimestamp: 1401318000000,
+        receivedTimestamp: 1401318000000
       });
       store.receivedTextChatMessage({
         contentType: CHAT_CONTENT_TYPES.TEXT,
         message: "Is it me you're looking for?",
-        sentTimestamp: "1970-01-01T00:03:00.000Z",
-        receivedTimestamp: "1970-01-01T00:03:00.000Z"
+        sentTimestamp: 1401318000000,
+        receivedTimestamp: 1401318000000
       });
 
       var node = ReactDOM.findDOMNode(view);
@@ -569,14 +571,14 @@ describe("loop.shared.views.TextChatView", function() {
       expect(entries[1].classList.contains("received")).to.eql(true);
     });
 
-    it("should not add received message if sent before", function() {
+    it("should not add a received message if it was sent before", function() {
       var node = ReactDOM.findDOMNode(mountTestComponent());
       store.setStoreState({ "displayName": "Myself" });
       let message = {
         contentType: CHAT_CONTENT_TYPES.TEXT,
         displayName: "Myself",
         message: "Foo",
-        sentTimestamp: "2015-06-25T17:53:55.357Z"
+        sentTimestamp: 1435254835357
       };
       store.sendTextChatMessage(message);
       store.receivedTextChatMessage(message);
@@ -594,8 +596,8 @@ describe("loop.shared.views.TextChatView", function() {
           contentType: CHAT_CONTENT_TYPES.TEXT,
           displayName: "Other user",
           message: "Foo",
-          sentTimestamp: "1970-01-01T00:03:00.000Z",
-          receivedTimestamp: "1970-01-01T00:03:00.000Z"
+          sentTimestamp: 1401318000000,
+          receivedTimestamp: 1401318000000
         });
 
         expect(node.querySelector(".received")).to.not.eql(null);
@@ -721,7 +723,8 @@ describe("loop.shared.views.TextChatView", function() {
         new sharedActions.SendTextChatMessage({
           contentType: CHAT_CONTENT_TYPES.TEXT,
           message: "Hello!",
-          sentTimestamp: "1970-01-01T00:00:00.000Z"
+          sentTimestamp: 1435254895357 // "2015-06-25T17:54:55.357Z"
+                                       // set on clock.tick line 502
         }));
     });
 
@@ -746,8 +749,8 @@ describe("loop.shared.views.TextChatView", function() {
         contentType: CHAT_CONTENT_TYPES.TEXT,
         displayName: "Other user",
         message: "Foo",
-        sentTimestamp: "1970-01-01T00:03:00.000Z",
-        receivedTimestamp: "1970-01-01T00:03:00.000Z"
+        sentTimestamp: 1401318000000,
+        receivedTimestamp: 1401318000000
       });
 
       var textBox = ReactDOM.findDOMNode(view).querySelector(".text-chat-box input");
@@ -763,7 +766,7 @@ describe("loop.shared.views.TextChatView", function() {
         contentType: CHAT_CONTENT_TYPES.TEXT,
         displayName: "Myself",
         message: "Foo",
-        sentTimestamp: "2015-06-25T17:53:55.357Z"
+        sentTimestamp: 1435254835357
       });
 
       var textBox = ReactDOM.findDOMNode(view).querySelector(".text-chat-box input");
@@ -783,17 +786,63 @@ describe("loop.shared.views.TextChatView", function() {
         expect(node.querySelector(".text-chat-notif")).to.not.eql(null);
     });
 
-    it("should render an icon for contentType NOTIFICATION",
-        function() {
-          view = mountTestComponent();
+    it("should render an icon for contentType NOTIFICATION", function() {
+      view = mountTestComponent();
 
-          store.remotePeerDisconnected(new sharedActions.RemotePeerDisconnected({
-            peerHungup: true
-          }));
+      store.remotePeerDisconnected(new sharedActions.RemotePeerDisconnected({
+        peerHungup: true
+      }));
 
-          var node = ReactDOM.findDOMNode(view);
-          expect(node.querySelectorAll(".notification-icon").length).to.eql(1);
+      var node = ReactDOM.findDOMNode(view);
+      expect(node.querySelectorAll(".notification-icon").length).to.eql(1);
+    });
+
+    describe("> Page events", function() {
+      let addedAction = {
+        pageId: "fake id",
+        added_by: "fakeUser",
+        added_time: 1435254895357, // "2015-06-25T17:54:55.357Z"
+        metadata: {
+          title: "TheWebTitle",
+          thumbnail_img: "the_image.ico",
+          url: "TheWebURL"
+        }
+      };
+
+      it("should render a TILE.ADDED when adding a page", function() {
+        view = mountTestComponent();
+
+        store.addedPage(new sharedActions.AddedPage(addedAction));
+
+        var eventTile = ReactDOM.findDOMNode(view)
+                        .querySelectorAll(".tile-event");
+        var addedEvent = ReactDOM.findDOMNode(view)
+                        .querySelectorAll(".added-tile");
+
+        expect(eventTile.length).to.eql(1);
+        expect(addedEvent.length).to.eql(1);
+      });
+
+      it("should render a TILE.DELETED when removing a page", function() {
+        view = mountTestComponent();
+        let deletedAction = Object.assign(addedAction, {
+          deleted: {
+            by: "deleter name",
+            timestamp: 1435254895357 // "2015-06-25T17:54:55.357Z"
+          }
         });
+
+        store.deletedPage(new sharedActions.DeletedPage(deletedAction));
+
+        var eventTile = ReactDOM.findDOMNode(view)
+                        .querySelectorAll(".tile-event");
+        var deletedEvent = ReactDOM.findDOMNode(view)
+                            .querySelectorAll(".deleted-tile");
+
+        expect(eventTile.length).to.eql(1);
+        expect(deletedEvent.length).to.eql(1);
+      });
+    });
   });
 
   describe("Add page button", () => {

--- a/shared/test/toc_test.js
+++ b/shared/test/toc_test.js
@@ -188,7 +188,7 @@ describe("loop.TableOfContents", () => {
             title: "fakeTitle",
             thumbnail_img: "fakeImg",
             url: "http://www.invalidurl.com",
-            userName: "Cool name"
+            username: "Cool name"
           }
         }));
     }

--- a/ui/ui-showcase.jsx
+++ b/ui/ui-showcase.jsx
@@ -293,30 +293,30 @@
   dispatcher.dispatch(new sharedActions.SendTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "Rheet!",
-    sentTimestamp: "2015-06-23T22:21:45.590Z"
+    sentTimestamp: 1435098105590 // "2015-06-23T22:21:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.ReceivedTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "Hello",
-    receivedTimestamp: "2015-06-23T23:24:45.590Z"
+    receivedTimestamp: 1435101885590 // "2015-06-23T23:24:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.SendTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "Nowforareallylongwordwithoutspacesorpunctuationwhichshouldcause" +
     "linewrappingissuesifthecssiswrong",
-    sentTimestamp: "2015-06-23T22:23:45.590Z"
+    sentTimestamp: 1435098225590 // "2015-06-23T22:23:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.SendTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "Check out this menu from DNA Pizza:" +
     " http://example.com/DNA/pizza/menu/lots-of-different-kinds-of-pizza/" +
     "%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%8D%E0%B8%88%E0%B8%A1%E0%B8%A3%E0%",
-    sentTimestamp: "2015-06-23T22:23:45.590Z"
+    sentTimestamp: 1435098225590 // "2015-06-23T22:23:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.ReceivedTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "That avocado monkey-brains pie sounds tasty!",
-    receivedTimestamp: "2015-06-23T22:25:45.590Z"
+    receivedTimestamp: 1435098345590 // "2015-06-23T22:25:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.SendTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.CONTEXT_TILE,
@@ -325,22 +325,22 @@
       roomToken: "fake",
       newRoomURL: "http://marvelous.invalid"
     },
-    sentTimestamp: "2015-06-23T22:25:46.590Z"
+    sentTimestamp: 1435098346590 // "2015-06-23T22:25:46.590Z"
   }));
   dispatcher.dispatch(new sharedActions.SendTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "What time should we meet?",
-    sentTimestamp: "2015-06-23T22:27:45.590Z"
+    sentTimestamp: 1435098465590 // "2015-06-23T22:27:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.ReceivedTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.TEXT,
     message: "8:00 PM",
-    receivedTimestamp: "2015-06-23T22:27:45.590Z"
+    receivedTimestamp: 1435098465590 // "2015-06-23T22:27:45.590Z"
   }));
   dispatcher.dispatch(new sharedActions.ReceivedTextChatMessage({
     contentType: loop.shared.utils.CHAT_CONTENT_TYPES.NOTIFICATION,
     message: "peer_unexpected_quit",
-    receivedTimestamp: "2015-06-23T22:28:45.590Z"
+    receivedTimestamp: 1435098525590 // "2015-06-23T22:28:45.590Z"
   }));
 
   loop.store.StoreMixin.register({


### PR DESCRIPTION
- Modified way pages are removed, from erasing the data to just mark it as 'deleted'
- Standardised use of timestamps to Number (we had a mix of String [ISO date] and Number [milliseconds])
- Still not showing tiles when recovering info on reload, just the live events
